### PR TITLE
Add e2e prow tests

### DIFF
--- a/tests/BasicTestMount.yaml
+++ b/tests/BasicTestMount.yaml
@@ -1,0 +1,24 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: basic-test-mount
+spec:
+  serviceAccountName: basic-test-mount-sa
+  containers:
+  - image: k8s.gcr.io/e2e-test-images/busybox:1.29
+    name: busybox
+    imagePullPolicy: IfNotPresent
+    command:
+    - "/bin/sleep"
+    - "10000"
+    volumeMounts:
+    - name: secrets-store-inline
+      mountPath: "/mnt/secrets-store"
+      readOnly: true
+  volumes:
+    - name: secrets-store-inline
+      csi:
+        driver: secrets-store.csi.k8s.io
+        readOnly: true
+        volumeAttributes:
+          secretProviderClass: "basic-test-mount-spc"

--- a/tests/BasicTestMountSPC.yaml
+++ b/tests/BasicTestMountSPC.yaml
@@ -1,0 +1,29 @@
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: basic-test-mount-spc
+spec:
+  provider: aws   
+  secretObjects:
+  - secretName: secret
+    type: Opaque
+    data:
+    - objectName: SecretsManagerSync
+      key: username
+  parameters:
+    objects: | 
+        - objectName: "ParameterStoreTest1"
+          objectType: "ssmparameter"
+        - objectName: "ParameterStoreTestWithLongName"
+          objectAlias: "ParameterStoreTest2"
+          objectType: "ssmparameter"
+        - objectName: "ParameterStoreRotationTest"
+          objectType: "ssmparameter"
+        - objectName: "SecretsManagerRotationTest"
+          objectType: "secretsmanager"
+        - objectName: "SecretsManagerTest1"
+          objectType: "secretsmanager"
+        - objectName: arn:aws:secretsmanager:${REGION}:${ACCOUNT_NUMBER}:secret:SecretsManagerTest2
+          objectAlias: "SecretsManagerTest2"
+        - objectName: "SecretsManagerSync"
+          objectType: "secretsmanager"

--- a/tests/README
+++ b/tests/README
@@ -1,0 +1,5 @@
+Running prow tests
+`
+1. Complete the private build section of the README - "Private Builds" - https://github.com/aws/secrets-store-csi-driver-provider-aws
+2. Install bats - https://github.com/bats-core/bats-core
+3. Once bats is installed, you can run "bats aws.bats" to run the e2e tests. Make sure to have the PRIVREPO environmental variable set to your private registry

--- a/tests/aws.bats
+++ b/tests/aws.bats
@@ -1,0 +1,150 @@
+#!/usr/bin/env bats
+ 
+load helpers 
+ 
+WAIT_TIME=120
+SLEEP_TIME=1
+PROVIDER_YAML=../deployment/private-installer.yaml
+NAMESPACE=kube-system
+CLUSTER_NAME=integ-cluster
+POD_NAME=basic-test-mount
+export REGION=us-west-2
+export ACCOUNT_NUMBER=$(aws --region $REGION  sts get-caller-identity --query Account --output text)
+  
+setup_file() {
+    #Create and initialize cluster 
+    eksctl create cluster \
+       --name $CLUSTER_NAME \
+       --node-type m5.large \
+       --nodes 3 \
+       --region $REGION
+ 
+   eksctl utils associate-iam-oidc-provider --name $CLUSTER_NAME --approve --region $REGION
+    
+   eksctl create iamserviceaccount \
+       --name basic-test-mount-sa \
+       --namespace $NAMESPACE \
+       --cluster $CLUSTER_NAME \
+       --attach-policy-arn arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess \
+       --attach-policy-arn arn:aws:iam::aws:policy/SecretsManagerReadWrite \
+       --override-existing-serviceaccounts \
+       --approve \
+       --region $REGION    
+    #Install csi secret driver
+    helm repo add secrets-store-csi-driver https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/charts
+    helm --namespace=$NAMESPACE install csi-secrets-store secrets-store-csi-driver/secrets-store-csi-driver --set enableSecretRotation=true --set rotationPollInterval=15s 
+ 
+   #Create test secrets
+   aws secretsmanager create-secret --name SecretsManagerTest1 --secret-string SecretsManagerTest1Value --region $REGION
+   aws secretsmanager create-secret --name SecretsManagerTest2 --secret-string SecretsManagerTest2Value --region $REGION
+   aws secretsmanager create-secret --name SecretsManagerSync --secret-string SecretUser --region $REGION
+ 
+   aws ssm put-parameter --name ParameterStoreTest1 --value ParameterStoreTest1Value --type SecureString --region $REGION
+   aws ssm put-parameter --name ParameterStoreTestWithLongName --value ParameterStoreTest2Value --type SecureString --region $REGION
+ 
+   aws ssm put-parameter --name ParameterStoreRotationTest --value BeforeRotation --type SecureString --region $REGION
+   aws secretsmanager create-secret --name SecretsManagerRotationTest --secret-string BeforeRotation --region $REGION
+}
+ 
+teardown_file() { 
+    eksctl delete cluster \
+        --name $CLUSTER_NAME \
+        --region $REGION
+ 
+    aws secretsmanager delete-secret --secret-id SecretsManagerTest1 --force-delete-without-recovery --region $REGION
+    aws secretsmanager delete-secret --secret-id SecretsManagerTest2 --force-delete-without-recovery --region $REGION
+    aws secretsmanager delete-secret --secret-id SecretsManagerSync --force-delete-without-recovery --region $REGION
+ 
+    aws ssm delete-parameter --name ParameterStoreTest1 --region $REGION
+    aws ssm delete-parameter --name ParameterStoreTestWithLongName --region $REGION 
+ 
+    aws ssm delete-parameter --name ParameterStoreRotationTest --region $REGION
+    aws secretsmanager delete-secret --secret-id SecretsManagerRotationTest --force-delete-without-recovery --region $REGION
+}
+ 
+@test "Install aws provider" {
+    envsubst < $PROVIDER_YAML | kubectl apply -f - 
+    cmd="kubectl --namespace $NAMESPACE wait --for=condition=Ready --timeout=60s pod -l app=csi-secrets-store-provider-aws"
+    wait_for_process $WAIT_TIME $SLEEP_TIME "$cmd"
+ 
+    PROVIDER_POD=$(kubectl --namespace $NAMESPACE get pod -l app=csi-secrets-store-provider-aws -o jsonpath="{.items[0].metadata.name}")	
+    run kubectl --namespace $NAMESPACE get pod/$PROVIDER_POD
+    assert_success
+}
+
+@test "secretproviderclasses crd is established" {
+    cmd="kubectl wait --namespace $NAMESPACE --for condition=established --timeout=60s crd/secretproviderclasses.secrets-store.csi.x-k8s.io"
+    wait_for_process $WAIT_TIME $SLEEP_TIME "$cmd"
+ 
+    run kubectl get crd/secretproviderclasses.secrets-store.csi.x-k8s.io
+    assert_success
+}
+ 
+@test "deploy aws secretproviderclass crd" {
+    envsubst < BasicTestMountSPC.yaml | kubectl --namespace $NAMESPACE apply -f -
+ 
+    cmd="kubectl --namespace $NAMESPACE get secretproviderclasses.secrets-store.csi.x-k8s.io/basic-test-mount-spc -o yaml | grep aws"
+    wait_for_process $WAIT_TIME $SLEEP_TIME "$cmd"
+}
+ 
+@test "CSI inline volume test with pod portability" {
+   kubectl --namespace $NAMESPACE  apply -f BasicTestMount.yaml
+   cmd="kubectl --namespace $NAMESPACE  wait --for=condition=Ready --timeout=60s pod/basic-test-mount"
+   wait_for_process $WAIT_TIME $SLEEP_TIME "$cmd"
+ 
+   run kubectl --namespace $NAMESPACE  get pod/$POD_NAME
+   assert_success
+}
+ 
+@test "CSI inline  volume test with rotation - parameter store " {
+   result=$(kubectl --namespace $NAMESPACE exec $POD_NAME -- cat /mnt/secrets-store/ParameterStoreRotationTest)
+   [[ "${result//$'\r'}" == "BeforeRotation" ]]
+ 
+   aws ssm put-parameter --name ParameterStoreRotationTest --value AfterRotation --type SecureString --overwrite --region $REGION
+   sleep 20
+   result=$(kubectl --namespace $NAMESPACE exec $POD_NAME -- cat /mnt/secrets-store/ParameterStoreRotationTest)
+   [[ "${result//$'\r'}" == "AfterRotation" ]]
+}
+ 
+@test "CSI inline volume test with rotation - secrets manager " {
+   result=$(kubectl --namespace $NAMESPACE exec $POD_NAME -- cat /mnt/secrets-store/SecretsManagerRotationTest)
+   [[ "${result//$'\r'}" == "BeforeRotation" ]]
+  
+   aws secretsmanager put-secret-value --secret-id SecretsManagerRotationTest --secret-string AfterRotation --region $REGION
+   sleep 20
+   result=$(kubectl --namespace $NAMESPACE exec $POD_NAME -- cat /mnt/secrets-store/SecretsManagerRotationTest)
+   [[ "${result//$'\r'}" == "AfterRotation" ]]
+}
+ 
+@test "CSI inline volume test with pod portability - read ssm parameters from pod" {
+   result=$(kubectl --namespace $NAMESPACE exec $POD_NAME -- cat /mnt/secrets-store/ParameterStoreTest1)
+   [[ "${result//$'\r'}" == "ParameterStoreTest1Value" ]]
+ 
+   result=$(kubectl --namespace $NAMESPACE exec $POD_NAME -- cat /mnt/secrets-store/ParameterStoreTest2)
+   [[ "${result//$'\r'}" == "ParameterStoreTest2Value" ]]
+}
+ 
+ 
+@test "CSI inline volume test with pod portability - read secrets manager secrets from pod" {
+    result=$(kubectl --namespace $NAMESPACE exec $POD_NAME -- cat /mnt/secrets-store/SecretsManagerTest1)
+    [[ "${result//$'\r'}" == "SecretsManagerTest1Value" ]]
+   
+    result=$(kubectl --namespace $NAMESPACE exec $POD_NAME -- cat /mnt/secrets-store/SecretsManagerTest2)
+    [[ "${result//$'\r'}" == "SecretsManagerTest2Value" ]]        
+}
+ 
+@test "Sync with Kubernetes Secret" {
+    run kubectl get secret --namespace $NAMESPACE  secret
+    [ "$status" -eq 0 ]
+ 
+    result=$(kubectl --namespace=$NAMESPACE get secret secret -o jsonpath="{.data.username}" | base64 -d)
+    [[ "$result" == "SecretUser" ]]
+}
+ 
+@test "Sync with Kubernetes Secret - Delete deployment. Secret should also be deleted" {
+    run kubectl --namespace $NAMESPACE  delete -f BasicTestMount.yaml
+    assert_success
+ 
+    run wait_for_process $WAIT_TIME $SLEEP_TIME "check_secret_deleted secret $NAMESPACE"
+    assert_success
+}

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+assert_success() {
+  if [[ "$status" != 0 ]]; then
+    echo "expected: 0"
+    echo "actual: $status"
+    echo "output: $output"
+    return 1
+  fi
+}
+
+assert_failure() {
+  if [[ "$status" == 0 ]]; then
+    echo "expected: non-zero exit code"
+    echo "actual: $status"
+    echo "output: $output"
+    return 1
+  fi
+}
+
+assert_equal() {
+  if [[ "$1" != "$2" ]]; then
+    echo "expected: $1"
+    echo "actual: $2"
+    return 1
+  fi
+}
+
+assert_not_equal() {
+  if [[ "$1" == "$2" ]]; then
+    echo "unexpected: $1"
+    echo "actual: $2"
+    return 1
+  fi
+}
+
+assert_match() {
+  if [[ ! "$2" =~ $1 ]]; then
+    echo "expected: $1"
+    echo "actual: $2"
+    return 1
+  fi
+}
+
+assert_not_match() {
+  if [[ "$2" =~ $1 ]]; then
+    echo "expected: $1"
+    echo "actual: $2"
+    return 1
+  fi
+}
+
+wait_for_process(){
+  wait_time="$1"
+  sleep_time="$2"
+  cmd="$3"
+  while [ "$wait_time" -gt 0 ]; do
+    if eval "$cmd"; then
+      return 0
+    else
+      sleep "$sleep_time"
+      wait_time=$((wait_time-sleep_time))
+    fi
+  done
+  return 1
+}
+
+compare_owner_count() {
+  secret="$1"
+  namespace="$2"
+  ownercount="$3"
+
+  [[ "$(kubectl get secret ${secret} -n ${namespace} -o json | jq '.metadata.ownerReferences | length')" -eq $ownercount ]]
+}
+
+check_secret_deleted() {
+  secret="$1"
+  namespace="$2"
+
+  result=$(kubectl get secret -n ${namespace} | grep "^${secret}$" | wc -l)
+  [[ "$result" -eq 0 ]]
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

These are the e2e prow bats tests for the kubernetes aws csi secret driver. They can be run via the instructions in the ReadMe in the tests directory 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
