### PR TITLE
Added helm chart using existing yaml

### DIFF
--- a/deployment/secrets-store-aws-provider-installer/.helmignore
+++ b/deployment/secrets-store-aws-provider-installer/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deployment/secrets-store-aws-provider-installer/Chart.yaml
+++ b/deployment/secrets-store-aws-provider-installer/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: secrets-store-aws-provider-installer
+description: AWS Secrets Manager and Config Provider
+
+type: application
+
+version: 0.1.0
+
+appVersion: 1.16.0

--- a/deployment/secrets-store-aws-provider-installer/templates/NOTES.txt
+++ b/deployment/secrets-store-aws-provider-installer/templates/NOTES.txt
@@ -1,0 +1,1 @@
+AWS Secrets Manager and Config Provider has been installed

--- a/deployment/secrets-store-aws-provider-installer/templates/_helpers.tpl
+++ b/deployment/secrets-store-aws-provider-installer/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "secrets-store-csi-driver-provider-aws.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "secrets-store-csi-driver-provider-aws.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "secrets-store-csi-driver-provider-aws.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "secrets-store-csi-driver-provider-aws.labels" -}}
+helm.sh/chart: {{ include "secrets-store-csi-driver-provider-aws.chart" . }}
+{{ include "secrets-store-csi-driver-provider-aws.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "secrets-store-csi-driver-provider-aws.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "secrets-store-csi-driver-provider-aws.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "secrets-store-csi-driver-provider-aws.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "secrets-store-csi-driver-provider-aws.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deployment/secrets-store-aws-provider-installer/templates/aws-provider-installer.yaml
+++ b/deployment/secrets-store-aws-provider-installer/templates/aws-provider-installer.yaml
@@ -1,0 +1,1 @@
+../../aws-provider-installer.yaml

--- a/deployment/secrets-store-aws-provider-installer/values.yaml
+++ b/deployment/secrets-store-aws-provider-installer/values.yaml
@@ -1,0 +1,1 @@
+# No config available


### PR DESCRIPTION
Fixes issue #15

Using the existing yaml file I have created a helm chart so that there's no need to maintain two separate versions of the same yaml. I can also submit an github action to release this helm chart as you do on other AWS repos if this approach gets accepted

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
