### PR TITLE
Add comments about Fargate not being supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ AWS offers two services to manage secrets and parameters conveniently in your co
   **Note** that older versions of the driver may require the ```--set grpcSupportedProviders="aws"``` flag on the install step.
 * IAM Roles for Service Accounts ([IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)) as described in the usage section below.
 
-[^1]: The CSI Secret Store driver runs as a DeamonSet, and as described in the [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/fargate.html#fargate-considerations), DeamonSet is not supported on Fargate. There are alternative options such as this [POC](https://aws.amazon.com/blogs/containers/aws-secrets-controller-poc/) or [external-secrets](https://github.com/external-secrets/external-secrets).
-
+[^1]: The CSI Secret Store driver runs as a DaemonSet, and as described in the [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/fargate.html#fargate-considerations), DaemonSet is not supported on Fargate. 
 
 ### Installing the AWS Provider
 To install the Secrets Manager and Config Provider use the YAML file in the deployment directory:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ AWS offers two services to manage secrets and parameters conveniently in your co
 ## Installation
 
 ### Requirements
-* Amazon Elastic Kubernetes Service (EKS) 1.17+
+* Amazon Elastic Kubernetes Service (EKS) 1.17+ using ECS (Fargate is not supported **[^1]**)
 * [Secrets Store CSI driver installed](https://secrets-store-csi-driver.sigs.k8s.io/getting-started/installation.html):
     ```shell
     helm repo add secrets-store-csi-driver https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/charts
@@ -14,9 +14,11 @@ AWS offers two services to manage secrets and parameters conveniently in your co
   **Note** that older versions of the driver may require the ```--set grpcSupportedProviders="aws"``` flag on the install step.
 * IAM Roles for Service Accounts ([IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)) as described in the usage section below.
 
+[^1]: The CSI Secret Store driver runs as a DeamonSet, and as described in the [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/fargate.html#fargate-considerations), DeamonSet is not supported on Fargate. There are alternative options such as this [POC](https://aws.amazon.com/blogs/containers/aws-secrets-controller-poc/) or [external-secrets](https://github.com/external-secrets/external-secrets).
+
 
 ### Installing the AWS Provider
-To install the Secrets Manger and Config Provider use the YAML file in the deployment directory:
+To install the Secrets Manager and Config Provider use the YAML file in the deployment directory:
 ```shell
 kubectl apply -f https://raw.githubusercontent.com/aws/secrets-store-csi-driver-provider-aws/main/deployment/aws-provider-installer.yaml
 ```


### PR DESCRIPTION
***Issue #, if available:***

Issue https://github.com/aws/secrets-store-csi-driver-provider-aws/issues/34

***Description of changes:***

As mentioned in this issue: https://github.com/aws/secrets-store-csi-driver-provider-aws/issues/34
Unfortunately, Fargate cannot support this built-in Kubernetes CSI Driver.

This PR just clarify this in the requirement adding a footnote with possible other solutions for Fargate

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
