### PR TITLE
chore: update driver chart repo to `https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ AWS offers two services to manage secrets and parameters conveniently in your co
 * Amazon Elastic Kubernetes Service (EKS) 1.17+
 * [Secrets Store CSI driver installed](https://secrets-store-csi-driver.sigs.k8s.io/getting-started/installation.html):
     ```shell
-    helm repo add secrets-store-csi-driver https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/charts
+    helm repo add secrets-store-csi-driver https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts
     helm install -n kube-system csi-secrets-store secrets-store-csi-driver/secrets-store-csi-driver
     ```
   **Note** that older versions of the driver may require the ```--set grpcSupportedProviders="aws"``` flag on the install step.

--- a/tests/aws.bats
+++ b/tests/aws.bats
@@ -37,7 +37,7 @@ setup_file() {
        --region $REGION    
    
    #Install csi secret driver
-   helm repo add secrets-store-csi-driver https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/charts
+   helm repo add secrets-store-csi-driver https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts
    helm --namespace=$NAMESPACE install csi-secrets-store secrets-store-csi-driver/secrets-store-csi-driver --set enableSecretRotation=true --set rotationPollInterval=15s --set syncSecret.enabled=true
  
    #Create test secrets


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

*Issue #, if available:*

*Description of changes:*
The driver chart repo was changed to `https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
