### PR TITLE
add parsing of klog CLI parameters

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,7 +28,9 @@ var (
 // rountine starts up the gRPC server that will listen for incoming mount
 // requests.
 func main() {
-
+	klog.InitFlags(nil)
+	defer klog.Flush()
+	
 	klog.Infof("Starting %s version %s", auth.ProviderName, server.Version)
 
 	flag.Parse() // Parse command line flags


### PR DESCRIPTION
*Description of changes:*

Add parsing of klog CLI parameters as seen on https://pkg.go.dev/k8s.io/klog#pkg-overview

This replicate behaviour of secrets-store-csi-driver and greatly aids debugging - for example by passing `-v=8` to pod parameters (it can help if networking is broken as you can see what HTTP request hangs). 

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
