### PR TITLE
add support for priorityClassName

### DIFF
--- a/charts/secrets-store-csi-driver-provider-aws/templates/daemonset.yaml
+++ b/charts/secrets-store-csi-driver-provider-aws/templates/daemonset.yaml
@@ -41,6 +41,9 @@ spec:
             - name: mountpoint-dir
               mountPath: /var/lib/kubelet/pods
               mountPropagation: HostToContainer
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
       volumes:
         - name: providervol
           hostPath:

--- a/charts/secrets-store-csi-driver-provider-aws/values.yaml
+++ b/charts/secrets-store-csi-driver-provider-aws/values.yaml
@@ -9,6 +9,7 @@ providerVolume: "/etc/kubernetes/secrets-store-csi-providers"
 
 podLabels: {}
 podAnnotations: {}
+priorityClassName: ""
 
 resources:
   requests:


### PR DESCRIPTION
**Issue #:** N/A

**Description of changes:**
This will just add the ability to configure a [`priorityClassName`](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass) for pod scheduling priority. We're seeing contention with Karpenter when daemonsets are getting scheduled and having enough resources at that time to schedule all other workloads.  Secrets Store CSI should have priority.