### PR TITLE
Update resource metadata version

### DIFF
--- a/examples/ExampleSecretProviderClass.yaml
+++ b/examples/ExampleSecretProviderClass.yaml
@@ -1,4 +1,4 @@
-apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
   name: nginx-deployment-aws-secrets


### PR DESCRIPTION
*Description of changes:*
Updating resource version as per this error:
`Warning: secrets-store.csi.x-k8s.io/v1alpha1 is deprecated. Use secrets-store.csi.x-k8s.io/v1 instead.`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.