### PR TITLE
Fix region preference for non-replicated secrets.

### DIFF
--- a/provider/secrets_manager_provider.go
+++ b/provider/secrets_manager_provider.go
@@ -81,7 +81,7 @@ func (p *SecretsManagerProvider) fetchSecretManagerValue(
 			return nil, err
 		}
 
-		if len(secretVal) > 0 {
+		if len(secretVal) > 0 && len(value) == 0 {
 			value = secretVal
 		}
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1016,7 +1016,7 @@ var mountTestsForMultiRegion []testCase = []testCase{
 			},
 		},
 		brGsvRsp: []*secretsmanager.GetSecretValueOutput{
-			{SecretString: aws.String("secret1"), VersionId: aws.String("wrongSecret")},
+			{SecretString: aws.String("wrongSecret"), VersionId: aws.String("1")},
 		},
 		brDescRsp: []*secretsmanager.DescribeSecretOutput{
 			{VersionIdsToStages: map[string][]*string{"TestSecret1": {aws.String("wrongSecret")}}},


### PR DESCRIPTION
*Description of changes:*
If different secrets are found in the primary and failover regions, the primary region's secret value should be mounted. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
