### PR TITLE
Add imagePullSecrets to the Helm Chart

### DIFF
--- a/charts/secrets-store-csi-driver-provider-aws/templates/daemonset.yaml
+++ b/charts/secrets-store-csi-driver-provider-aws/templates/daemonset.yaml
@@ -49,6 +49,10 @@ spec:
           hostPath:
             path: /var/lib/kubelet/pods
             type: DirectoryOrCreate
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
       nodeSelector:
         kubernetes.io/os: linux
 {{- if .Values.nodeSelector }}

--- a/charts/secrets-store-csi-driver-provider-aws/values.yaml
+++ b/charts/secrets-store-csi-driver-provider-aws/values.yaml
@@ -33,3 +33,5 @@ rbac:
 securityContext:
   privileged: false
   allowPrivilegeEscalation: false
+
+imagePullSecrets: []


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added imagePullSecrets to the daemonset to use if you need a secret to authenticate with a container repository.

This change was deployed to an EKS cluster using a built tar.gz file of the chart.
`https://github.com/ni/secrets-store-csi-driver-provider-aws/releases/download/0.1.0/0-1-0.tar.gz`



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
