### PR TITLE
Add warning printout on non-fatal error.

### DIFF
--- a/provider/parameter_store_provider.go
+++ b/provider/parameter_store_provider.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/aws/aws-sdk-go/service/ssm/ssmiface"
 	"github.com/aws/secrets-store-csi-driver-provider-aws/utils"
+	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/secrets-store-csi-driver/provider/v1alpha1"
 )
@@ -85,7 +86,10 @@ func (p *ParameterStoreProvider) fetchParameterStoreValue(
 
 		if utils.IsFatalError(err) {
 			return nil, err
+		} else if err != nil {
+			klog.Warning(err)
 		}
+
 		if len(values) == 0 {
 			values = batchValues
 		}

--- a/provider/secrets_manager_provider.go
+++ b/provider/secrets_manager_provider.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/aws/aws-sdk-go/service/secretsmanager/secretsmanageriface"
 	"github.com/aws/secrets-store-csi-driver-provider-aws/utils"
+	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/secrets-store-csi-driver/provider/v1alpha1"
 )
@@ -79,6 +80,8 @@ func (p *SecretsManagerProvider) fetchSecretManagerValue(
 		//check if fatal(4XX status error) exist to error out the mount
 		if utils.IsFatalError(err) {
 			return nil, err
+		} else if err != nil {
+			klog.Warning(err)
 		}
 
 		if len(secretVal) > 0 && len(value) == 0 {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/secrets-store-csi-driver-provider-aws/issues/185
https://github.com/aws/secrets-store-csi-driver-provider-aws/issues/176

*Description of changes:*
If a non-fatal warning happens in fetchSecretManagerValueWithClient, the error message will get ignored in favor of the 'Failed to fetch secret' failure message.  This change will emit both error messages.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
