### PR TITLE
v1alpha1 isn't supported now moving forward 1.22 EKS

### DIFF
--- a/examples/ExampleSecretProviderClass.yaml
+++ b/examples/ExampleSecretProviderClass.yaml
@@ -1,4 +1,4 @@
-apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
   name: nginx-deployment-aws-secrets


### PR DESCRIPTION
Proposed Code:
```
apiVersion: secrets-store.csi.x-k8s.io/v1
kind: SecretProviderClass
metadata:
  name: nginx-deployment-aws-secrets
spec:
  provider: aws
  parameters:
    objects: |
        - objectName: "MySecret"
          objectType: "secretsmanager"
```

Please help to modify the code as it's linked to AWS Official Doc: https://docs.aws.amazon.com/secretsmanager/latest/userguide/integrating_csi_driver_tutorial.html

*Issue #, if available:*

*Description of changes:*
Modified apiVersion to v1 as v1alpha1 isn't supported anymore in 1.22 EKS Version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
