### PR TITLE
Adding Windows Support

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,29 @@
+name: Build Windows Image
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  build:
+    runs-on: windows-2022
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: "1.20"
+    - name: Make build
+      run: make -f Makefile.win build
+      shell: bash
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build and push
+      run: |
+        docker build . -f Dockerfile.win -t ghcr.io/saedx1/secrets-store-csi-driver-provider-aws:${{ github.ref_name }}
+        docker push ghcr.io/saedx1/secrets-store-csi-driver-provider-aws:${{ github.ref_name }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,9 +3,17 @@ name: Go
 on: [push, pull_request]
 
 jobs:
-
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+        - os: windows-latest
+          goos: windows
+        - os: ubuntu-latest
+          goos: linux
+    runs-on: ${{ matrix.os }}
+    env:
+      GOOS: ${{ matrix.goos }}
     steps:
     - uses: actions/checkout@v3
     - name: Set up Go

--- a/Dockerfile.win
+++ b/Dockerfile.win
@@ -1,0 +1,5 @@
+FROM mcr.microsoft.com/windows/nanoserver:ltsc2019 as base
+
+COPY ./_output/secrets-store-csi-driver-provider-aws-amd64 /secrets-store-csi-driver-provider-aws.exe
+
+ENTRYPOINT ["/secrets-store-csi-driver-provider-aws.exe"]

--- a/Makefile.win
+++ b/Makefile.win
@@ -1,0 +1,63 @@
+$(eval AWS_REGION=$(shell echo $${REGION:-us-east-1}))
+$(eval REGISTRY_NAME=$(shell echo $${PRIVREPO:-public.ecr.aws/aws-secrets-manager/secrets-store-csi-driver-provider-aws}))
+$(eval REPOBASE=$(shell echo $(REGISTRY_NAME) | cut -f1 -d/))
+
+ifeq ($(REPOBASE), public.ecr.aws)
+ECRCMD=ecr-public
+else
+ECRCMD=ecr
+endif
+
+IMAGE_NAME=secrets-store-csi-driver-provider-aws
+
+# Build for AMD64 and ARM64
+ARCHITECTURES=amd64
+GOOS=windows
+
+MAJOR_REV=1
+MINOR_REV=0
+$(eval PATCH_REV=$(shell git describe --always))
+$(eval BUILD_DATE=$(shell date -u +%Y.%m.%d.%H.%M))
+FULL_REV=$(MAJOR_REV).$(MINOR_REV).$(PATCH_REV)-$(BUILD_DATE)
+
+LDFLAGS?="-X github.com/aws/secrets-store-csi-driver-provider-aws/server.Version=$(FULL_REV) -extldflags "-static""
+
+CHART_RELEASER_PATH ?= cr
+
+.PHONY: all build clean docker-login docker-buildx docker-manifest
+
+# Build docker image and push to AWS registry
+all: build docker-login docker-buildx docker-manifest
+
+build: clean
+	$(foreach ARCH,$(ARCHITECTURES),CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(ARCH) go build -a -ldflags $(LDFLAGS) -o _output/$(IMAGE_NAME)-$(ARCH) ;)
+
+clean:
+	-rm -rf _output
+	-docker system prune --all --force
+
+docker-login:
+	aws --region $(AWS_REGION) $(ECRCMD) get-login-password | docker login -u AWS --password-stdin $(REPOBASE)
+
+# Build, tag, and push image for architecture
+docker-buildx:
+	$(foreach ARCH,$(ARCHITECTURES),docker buildx build \
+                --platform $(GOOS)/$(ARCH) \
+                --no-cache \
+                --push \
+                -t $(REGISTRY_NAME):latest-$(ARCH) \
+                -t $(REGISTRY_NAME):latest-$(GOOS)-$(ARCH) \
+                -t $(REGISTRY_NAME):$(FULL_REV)-$(GOOS)-$(ARCH) \
+                . ;)
+
+# Create and push manifest list for images
+docker-manifest:
+	docker buildx imagetools create --tag $(REGISTRY_NAME):latest $(foreach ARCH, $(ARCHITECTURES), $(REGISTRY_NAME):latest-$(ARCH))
+	docker buildx imagetools create --tag $(REGISTRY_NAME):$(FULL_REV) $(foreach ARCH, $(ARCHITECTURES), $(REGISTRY_NAME):latest-$(ARCH))
+	docker buildx imagetools create --tag $(REGISTRY_NAME):$(MAJOR_REV) $(foreach ARCH, $(ARCHITECTURES), $(REGISTRY_NAME):latest-$(ARCH))
+
+# Get a GitHub personal access token from the "Developer settings" section of your Github Account settings
+upload-helm:
+	cd charts/secrets-store-csi-driver-provider-aws && ${CHART_RELEASER_PATH} package
+	cd charts/secrets-store-csi-driver-provider-aws && ${CHART_RELEASER_PATH} upload -o aws -r secrets-store-csi-driver-provider-aws --token $(GITHUB_TOKEN) --skip-existing
+	cd charts/secrets-store-csi-driver-provider-aws && ${CHART_RELEASER_PATH} index -o aws -r secrets-store-csi-driver-provider-aws --token $(GITHUB_TOKEN) --push --index-path .

--- a/deployment/aws-provider-installer.yaml
+++ b/deployment/aws-provider-installer.yaml
@@ -88,3 +88,58 @@ spec:
             type: DirectoryOrCreate
       nodeSelector:
         kubernetes.io/os: linux
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  namespace: kube-system
+  name: csi-secrets-store-provider-aws-windows
+  labels:
+    app: csi-secrets-store-provider-aws-windows
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: csi-secrets-store-provider-aws-windows
+  template:
+    metadata:
+      labels:
+        app: csi-secrets-store-provider-aws-windows
+    spec:
+      serviceAccountName: csi-secrets-store-provider-aws
+      hostNetwork: false
+      containers:
+        - name: provider-aws-installer
+          image: ghcr.io/saedx1/secrets-store-csi-driver-provider-aws:1.0.1
+          imagePullPolicy: Always
+          args:
+              - --provider-volume=C:\k\secrets-store-csi-providers
+          resources:
+            requests:
+              cpu: 50m
+              memory: 100Mi
+            limits:
+              cpu: 50m
+              memory: 100Mi
+          securityContext:
+            privileged: false
+            allowPrivilegeEscalation: false
+          volumeMounts:
+            - mountPath: C:\k\secrets-store-csi-providers
+              name: providervol
+            - name: mountpoint-dir
+              mountPath: C:\var\lib\kubelet\pods
+              mountPropagation: HostToContainer
+      volumes:
+        - name: providervol
+          hostPath:
+            path: C:\k\secrets-store-csi-providers
+        - name: mountpoint-dir
+          hostPath:
+            path: C:\var\lib\kubelet\pods
+            type: DirectoryOrCreate
+      tolerations:
+        - operator: Exists
+      nodeSelector:
+        kubernetes.io/os: windows

--- a/deployment/aws-provider-installer.yaml
+++ b/deployment/aws-provider-installer.yaml
@@ -111,7 +111,7 @@ spec:
       hostNetwork: false
       containers:
         - name: provider-aws-installer
-          image: ghcr.io/saedx1/secrets-store-csi-driver-provider-aws:1.0.1
+          image: ghcr.io/saedx1/secrets-store-csi-driver-provider-aws:1.0.0
           imagePullPolicy: Always
           args:
               - --provider-volume=C:\k\secrets-store-csi-providers

--- a/provider/secret_descriptor.go
+++ b/provider/secret_descriptor.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/arn"
@@ -101,8 +102,14 @@ func (p *SecretDescriptor) GetFileName() (path string) {
 	// Translate slashes to underscore if required.
 	if len(p.translate) != 0 {
 		fileName = strings.ReplaceAll(fileName, string(os.PathSeparator), p.translate)
+		if runtime.GOOS == "windows" {
+			fileName = strings.ReplaceAll(fileName, "/", p.translate)
+		}
 	} else {
 		fileName = strings.TrimLeft(fileName, string(os.PathSeparator)) // Strip leading slash
+		if runtime.GOOS == "windows" {
+			fileName = strings.TrimLeft(fileName, "/") // Strip leading slash
+		}
 	}
 
 	return fileName

--- a/provider/secret_descriptor_test.go
+++ b/provider/secret_descriptor_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -321,10 +322,19 @@ func TestGetPath(t *testing.T) {
 	if len(descriptorList[SSMParameter]) != 1 || len(descriptorList[SecretsManager]) != 1 {
 		t.Fatalf("Missing descriptors")
 	}
-	if descriptorList[SSMParameter][0].GetMountPath() != "/mountpoint/parm1" {
+	
+	expectedParam := "/mountpoint/parm1"
+	expectedSecret := "/mountpoint/secret1"
+
+	if runtime.GOOS == "windows" {
+		expectedParam = "\\mountpoint\\parm1"
+		expectedSecret = "\\mountpoint\\secret1"
+	}
+
+	if descriptorList[SSMParameter][0].GetMountPath() != expectedParam {
 		t.Errorf("Bad mount path for SSM parameter")
 	}
-	if descriptorList[SecretsManager][0].GetMountPath() != "/mountpoint/secret1" {
+	if descriptorList[SecretsManager][0].GetMountPath() != expectedSecret {
 		t.Errorf("Bad mount path for secret")
 	}
 
@@ -572,7 +582,14 @@ func TestGetPathForMultiregion(t *testing.T) {
 	if len(descriptorList[SSMParameter]) != 1 {
 		t.Fatalf("Missing descriptors")
 	}
-	if descriptorList[SSMParameter][0].GetMountPath() != "/mountpoint/test" {
+	
+	expected := "/mountpoint/test"
+
+	if runtime.GOOS == "windows" {
+		expected = "\\mountpoint\\test"
+	}
+
+	if descriptorList[SSMParameter][0].GetMountPath() != expected {
 		t.Errorf("Bad mount path for SSM parameter")
 	}
 
@@ -615,7 +632,14 @@ func TestVersionidsMatch(t *testing.T) {
 	if len(descriptorList[SSMParameter]) != 1 {
 		t.Fatalf("Missing descriptors")
 	}
-	if descriptorList[SSMParameter][0].GetMountPath() != "/mountpoint/test" {
+	
+	expected := "/mountpoint/test"
+
+	if runtime.GOOS == "windows" {
+		expected = "\\mountpoint\\test"
+	}
+
+	if descriptorList[SSMParameter][0].GetMountPath() != expected {
 		t.Errorf("Bad mount path for SSM parameter")
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -318,6 +318,8 @@ func (s *CSIDriverProviderServer) writeFile(secret *provider.SecretValue, mode o
 		return nil, err
 	}
 
+	tmpFile.Close()
+
 	// Swap out the old secret for the new
 	err = os.Rename(tmpFile.Name(), secret.Descriptor.GetMountPath())
 	if err != nil {


### PR DESCRIPTION
*Issue #, if available:*
#131 

*Description of changes:*
- Closing a file before renaming it as this causes a problem on windows: `windows cannot access file because another process is using it`.
- In the translation of paths, unfortunately, `os.PathSeparator` isn't sufficient for windows. This is because windows also accepts `/` as a separator. Go's official `path_windows.go` actually does the same thing I'm adding https://go.dev/src/os/path_windows.go - see the first 16 lines of that file.
- I did build the image and push it to my personal github public container registry, so I can confirm that `Dockerfile.win` has been tested.
- I tested this on EKS with a windows node running 6 or more pods using secrets (as volumes and as env vars).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
