### PR TITLE
Fix priorityClassName location

### DIFF
--- a/charts/secrets-store-csi-driver-provider-aws/templates/daemonset.yaml
+++ b/charts/secrets-store-csi-driver-provider-aws/templates/daemonset.yaml
@@ -33,9 +33,6 @@ spec:
             - --provider-volume={{ .Values.providerVolume }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
-{{- if .Values.priorityClassName }}
-          priorityClassName: {{ .Values.priorityClassName | quote }}
-{{- end }}
           securityContext:
 {{ toYaml .Values.securityContext | indent 12 }}
           volumeMounts:
@@ -52,6 +49,9 @@ spec:
           hostPath:
             path: /var/lib/kubelet/pods
             type: DirectoryOrCreate
+{{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+{{- end }}
       nodeSelector:
         kubernetes.io/os: linux
 {{- if .Values.nodeSelector }}


### PR DESCRIPTION
*Description of changes:*

Fixes bug introduced in https://github.com/aws/secrets-store-csi-driver-provider-aws/pull/171

`priorityClassName` is not on `DaemonSet.spec.template.spec.containers` but on `DaemonSet.spec.template.spec`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
