### PR TITLE
Added env variables to helm chart daemonset

### DIFF
--- a/charts/secrets-store-csi-driver-provider-aws/templates/daemonset.yaml
+++ b/charts/secrets-store-csi-driver-provider-aws/templates/daemonset.yaml
@@ -31,6 +31,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --provider-volume={{ .Values.providerVolume }}
+{{- if .Values.env }}
+          env:
+{{ toYaml .Values.env | indent 12 }}
+{{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           securityContext:


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/secrets-store-csi-driver-provider-aws/issues/29

*Description of changes:* Add an env field to the helm chart daemonset to implement the proxy settings solution described in https://github.com/aws/secrets-store-csi-driver-provider-aws/issues/29 to the helm chart. These changes were testing against the existing values.yaml and a values.yaml with the following added:
```
env:
  - name: HTTP_PROXY
    value: http://example.com:912
  - name: HTTPS_PROXY
    value: http://example.com:912
  - name: NO_PROXY
    value: 10.0.0.0/8
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
