### PR TITLE
helm: affinity rule to ignore Fargate node

### DIFF
--- a/charts/secrets-store-csi-driver-provider-aws/values.yaml
+++ b/charts/secrets-store-csi-driver-provider-aws/values.yaml
@@ -10,7 +10,15 @@ providerVolume: "/etc/kubernetes/secrets-store-csi-providers"
 podLabels: {}
 podAnnotations: {}
 
-affinity: {}
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: "eks.amazonaws.com/compute-type"
+              operator: NotIn
+              values:
+              - fargate
 
 resources:
   requests:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

According to the [documentation](https://github.com/aws/secrets-store-csi-driver-provider-aws/tree/main#user-content-fn-1-0c6c2984bb6a6cae6602672fbc3fc9b5)),  the ASCP doesn't offer support for Fargate nodes because this kind of node is [incompatible](https://docs.aws.amazon.com/eks/latest/userguide/fargate.html#fargate-considerations) with daemonset workloads.
In the context of deploying a hybrid cluster consisting of Fargate-EC2 nodes, it is possible to deploy daemonsets on those EC2 nodes. However, it's important to note that the daemonsets will remain in a "pending" state on the Fargate nodes (due to the mentioned limitation). This recommendation was formulated to include the affinity rule by default in the values file to address this specific scenario. By including [this](https://github.com/aws/secrets-store-csi-driver-provider-aws/compare/main...ngarciaf:node_affinity?expand=1#diff-ae7f7fe6727b45a417593a7c26bb5c6efade257727fdf159fce3032a4122085eR13) affinity rule in the values file, it helps ensure proper scheduling and allocation of daemonsets only on the EC2 nodes.
Cheers!
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
