### PR TITLE
Fix nginx deployment Example 

### DIFF
--- a/examples/ExampleDeployment.yaml
+++ b/examples/ExampleDeployment.yaml
@@ -1,3 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nginx-deployment-sa
+  annotations:
+    eks.amazonaws.com/role-arn: <replace-with-arn:aws:iam::number:role/secret-name>
+---
 kind: Service
 apiVersion: v1
 metadata:

--- a/examples/ExampleSecretProviderClass.yaml
+++ b/examples/ExampleSecretProviderClass.yaml
@@ -1,4 +1,4 @@
-apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
   name: nginx-deployment-aws-secrets


### PR DESCRIPTION
Current Nginx deployment fails due to serviceAccount not being present and you get a warning for using `secrets-store.csi.x-k8s.io/v1alpha1`