### PR TITLE
Make throttling params qps and burst configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,25 @@ envsubst < deployment/private-installer.yaml | kubectl apply -f -
 
 The AWS Secrets Manager and Config Provider provides compatibility for legacy applications that access secrets as mounted files in the pod. Security conscious applications should use the native AWS APIs to fetch secrets and optionally cache them in memory rather than storing them in the file system.
 
+### Client-Side Rate-Limitting to Kubernetes API server
+
+To mount each secret on each pod, the AWS CSI provider lookups the region of the pod and the role ARN associated with the service account by calling the K8s APIs. You can increase the value of qps and burst if you notice the provider is throttled by client-side limit to the API server. Add your custom qps and burst to the definition of `csi-secrets-store-provider-aws` in `aws-provider-installer.yaml`
+
+```ymal
+kind: DaemonSet
+metadata:
+  namespace: kube-system
+  name: csi-secrets-store-provider-aws
+spec:
+  template:
+    spec:
+      containers:
+        - name: provider-aws-installer
+          args:
+              - --qps=<custom qps>
+              - --burst=<custom burst>
+```
+
 ## Security
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.

--- a/main.go
+++ b/main.go
@@ -22,8 +22,8 @@ import (
 var (
 	endpointDir        = flag.String("provider-volume", "/etc/kubernetes/secrets-store-csi-providers", "Rendezvous directory for provider socket")
 	driverWriteSecrets = flag.Bool("driver-writes-secrets", false, "The driver will do the write instead of the plugin")
-	qps                = flag.Int("qps", 5, "Maximum query per second to the master")
-	burst              = flag.Int("burst", 10, "Maximum burst for throttle")
+	qps                = flag.Int("qps", 5, "Maximum query per second to the Kubernetes API server. To mount the requested secret on the pod, the AWS CSI provider lookups the region of the pod and the role ARN associated with the service account by calling the K8s APIs. Increase the value if the provider is throttled by client-side limit to the API server.")
+	burst              = flag.Int("burst", 10, "Maximum burst for throttle. To mount the requested secret on the pod, the AWS CSI provider lookups the region of the pod and the role ARN associated with the service account by calling the K8s APIs. Increase the value if the provider is throttled by client-side limit to the API server.")
 )
 
 // Main entry point for the Secret Store CSI driver AWS provider. This main

--- a/main.go
+++ b/main.go
@@ -22,8 +22,8 @@ import (
 var (
 	endpointDir        = flag.String("provider-volume", "/etc/kubernetes/secrets-store-csi-providers", "Rendezvous directory for provider socket")
 	driverWriteSecrets = flag.Bool("driver-writes-secrets", false, "The driver will do the write instead of the plugin")
-	qps                = flag.Int("qps", 20, "Maximum query per second to the master")
-	burst              = flag.Int("burst", 40, "Maximum burst for throttle")
+	qps                = flag.Int("qps", 5, "Maximum query per second to the master")
+	burst              = flag.Int("burst", 10, "Maximum burst for throttle")
 )
 
 // Main entry point for the Secret Store CSI driver AWS provider. This main

--- a/main.go
+++ b/main.go
@@ -22,6 +22,8 @@ import (
 var (
 	endpointDir        = flag.String("provider-volume", "/etc/kubernetes/secrets-store-csi-providers", "Rendezvous directory for provider socket")
 	driverWriteSecrets = flag.Bool("driver-writes-secrets", false, "The driver will do the write instead of the plugin")
+	qps                = flag.Int("qps", 20, "Maximum query per second to the master")
+	burst              = flag.Int("burst", 40, "Maximum burst for throttle")
 )
 
 // Main entry point for the Secret Store CSI driver AWS provider. This main
@@ -57,6 +59,9 @@ func main() {
 	if err != nil {
 		klog.Fatalf("Can not get cluster config. error: %v", err)
 	}
+
+	cfg.QPS = float32(*qps)
+	cfg.Burst = *burst
 
 	clientset, err := kubernetes.NewForConfig(cfg)
 	if err != nil {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Kubernetes Go client uses a default value of 5 and 10 for QPS and burst. As a result, our customers may experience client-side rate limiting. This pull request makes them configurable to our customers.

*Related issues:* https://github.com/aws/secrets-store-csi-driver-provider-aws/issues/136


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
