### PR TITLE
Update to secrets-store.csi.x-k8s.io/v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Where **&lt;PODID&gt;** in this case is the id of the *csi-secrets-store-provide
 ### SecretProviderClass options
 The SecretProviderClass has the following format:
 ```yaml
-apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
   name: <NAME>

--- a/examples/ExampleSecretProviderClass.yaml
+++ b/examples/ExampleSecretProviderClass.yaml
@@ -1,4 +1,4 @@
-apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
   name: nginx-deployment-aws-secrets

--- a/tests/BasicTestMountSPC.yaml
+++ b/tests/BasicTestMountSPC.yaml
@@ -1,4 +1,4 @@
-apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
   name: basic-test-mount-spc


### PR DESCRIPTION
Update secrets-store.csi.x-k8s.io/v1alpha1 to secrets-store.csi.x-k8s.io/v1. Tested on k8s 1.29.