### PR TITLE
Add support for non-default kubelet root directory

### DIFF
--- a/charts/secrets-store-csi-driver-provider-aws/Chart.yaml
+++ b/charts/secrets-store-csi-driver-provider-aws/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: secrets-store-csi-driver-provider-aws
-version: 0.3.6
+version: 0.3.7
 kubeVersion: ">=1.17.0-0"
 description: A Helm chart for the AWS Secrets Manager and Config Provider for Secret Store CSI Driver
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/charts/secrets-store-csi-driver-provider-aws/templates/daemonset.yaml
+++ b/charts/secrets-store-csi-driver-provider-aws/templates/daemonset.yaml
@@ -47,7 +47,7 @@ spec:
             path: {{ .Values.providerVolume }}
         - name: mountpoint-dir
           hostPath:
-            path: /var/lib/kubelet/pods
+            path: {{ .Values.kubeletPath }}/pods
             type: DirectoryOrCreate
 {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}

--- a/charts/secrets-store-csi-driver-provider-aws/values.yaml
+++ b/charts/secrets-store-csi-driver-provider-aws/values.yaml
@@ -6,6 +6,7 @@ image:
 nameOverride: ""
 fullnameOverride: ""
 providerVolume: "/etc/kubernetes/secrets-store-csi-providers"
+kubeletPath: "/var/lib/kubelet"
 
 podLabels: {}
 podAnnotations: {}


### PR DESCRIPTION
We are working on expanding the ephemeral storage available to our nodes. We plan to accomplish this by using AWS instance types with ephemeral drives (e.g. `m7gd.2xlarge`) and updating the `kubelet` config to set `--root-dir=${PATH_ON_EPHEMERAL_DRIVE}`. 

When we went to roll this out, we ran into issues with the EBS CSI driver and the Secrets Store CSI Driver stack. The EBS CSI driver [has a variable](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/4fe5c80f8135198e948555f0a37ba643587c3cf7/charts/aws-ebs-csi-driver/templates/_node.tpl#L220) for this, and [so does](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/050f986c72bba34af60f1adeb9e1a6c734a4baa7/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml#L177) the core Secrets Store CSI Driver workload. The AWS provider for the Secrets Store CSI Driver does _not_ have a configurable for this, which keeps us from being able to change the `kubelet` root drive.

This changeset fixes this by adding a Helm chart variable `kubeletPath` and using it in the Helm chart. The name was cargo-culted from the name used in the EBS CSI driver, and the default value is what was previously hard-coded in the Helm template.