### PR TITLE
Allow users to configure the underlying AWS SDK to enable FIPS endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,32 @@ Once the image is in your repo you can install it into your cluster from your re
 envsubst < deployment/private-installer.yaml | kubectl apply -f -
 ```
 
+### Configure the Underlying Secrets Manager Client to Use FIPS Endpoint
+
+If you prefer to use Helm chart to install the provider, append the `--set-json 'secretsManagerClientConfig=[{"name": "AWS_USE_FIPS_ENDPOINT", "value": true}]'` flag on the install step. Your install command would be something like
+
+```shell
+helm repo add aws-secrets-manager https://aws.github.io/secrets-store-csi-driver-provider-aws
+helm install -n kube-system secrets-provider-aws aws-secrets-manager/secrets-store-csi-driver-provider-aws --set-json 'secretsManagerClientConfig=[{"name": "AWS_USE_FIPS_ENDPOINT", "value": true}]'
+```
+
+If you install the provider by the YAML file in the deployment directory, set environment variable `AWS_USE_FIPS_ENDPOINT` to be true in the definition of `csi-secrets-store-provider-aws` in `aws-provider-installer.yaml`
+
+```yaml
+kind: DaemonSet
+metadata:
+  namespace: kube-system
+  name: csi-secrets-store-provider-aws
+spec:
+  template:
+    spec:
+      containers:
+        - name: provider-aws-installer
+          env:
+            - name: AWS_USE_FIPS_ENDPOINT
+              value: true
+```
+
 ### Security Considerations
 
 The AWS Secrets Manager and Config Provider provides compatibility for legacy applications that access secrets as mounted files in the pod. Security conscious applications should use the native AWS APIs to fetch secrets and optionally cache them in memory rather than storing them in the file system.

--- a/README.md
+++ b/README.md
@@ -218,11 +218,11 @@ envsubst < deployment/private-installer.yaml | kubectl apply -f -
 
 ### Configure the Underlying Secrets Manager Client to Use FIPS Endpoint
 
-If you prefer to use Helm chart to install the provider, append the `--set-json 'secretsManagerClientConfig=[{"name": "AWS_USE_FIPS_ENDPOINT", "value": true}]'` flag on the install step. Your install command would be something like
+If you prefer to use Helm chart to install the provider, append the `--set useFipsEndpoint=true` flag on the install step. Your install command would be something like
 
 ```shell
 helm repo add aws-secrets-manager https://aws.github.io/secrets-store-csi-driver-provider-aws
-helm install -n kube-system secrets-provider-aws aws-secrets-manager/secrets-store-csi-driver-provider-aws --set-json 'secretsManagerClientConfig=[{"name": "AWS_USE_FIPS_ENDPOINT", "value": true}]'
+helm install -n kube-system secrets-provider-aws aws-secrets-manager/secrets-store-csi-driver-provider-aws --set useFipsEndpoint=true
 ```
 
 If you install the provider by the YAML file in the deployment directory, set environment variable `AWS_USE_FIPS_ENDPOINT` to be true in the definition of `csi-secrets-store-provider-aws` in `aws-provider-installer.yaml`

--- a/README.md
+++ b/README.md
@@ -218,28 +218,11 @@ envsubst < deployment/private-installer.yaml | kubectl apply -f -
 
 ### Configure the Underlying Secrets Manager Client to Use FIPS Endpoint
 
-If you prefer to use Helm chart to install the provider, append the `--set useFipsEndpoint=true` flag on the install step. Your install command would be something like
+If you use Helm chart to install the provider, append the `--set useFipsEndpoint=true` flag on the install step. Your install command would be something like
 
 ```shell
 helm repo add aws-secrets-manager https://aws.github.io/secrets-store-csi-driver-provider-aws
 helm install -n kube-system secrets-provider-aws aws-secrets-manager/secrets-store-csi-driver-provider-aws --set useFipsEndpoint=true
-```
-
-If you install the provider by the YAML file in the deployment directory, set environment variable `AWS_USE_FIPS_ENDPOINT` to be true in the definition of `csi-secrets-store-provider-aws` in `aws-provider-installer.yaml`
-
-```yaml
-kind: DaemonSet
-metadata:
-  namespace: kube-system
-  name: csi-secrets-store-provider-aws
-spec:
-  template:
-    spec:
-      containers:
-        - name: provider-aws-installer
-          env:
-            - name: AWS_USE_FIPS_ENDPOINT
-              value: true
 ```
 
 ### Security Considerations

--- a/charts/secrets-store-csi-driver-provider-aws/templates/daemonset.yaml
+++ b/charts/secrets-store-csi-driver-provider-aws/templates/daemonset.yaml
@@ -69,12 +69,8 @@ spec:
       affinity:
 {{ toYaml . | indent 8 }}
 {{- end }}
-{{- if .Values.secretsManagerClientConfig }}
+{{- if .Values.useFipsEndpoint }}
       env:
-        {{- range .Values.secretsManagerClientConfig }}
-        {{- if eq .name "AWS_USE_FIPS_ENDPOINT" }}
-        - name: {{ .name }}
-          value: {{ .value }}
-        {{- end }}
-        {{- end }}
+        - name: AWS_USE_FIPS_ENDPOINT
+          value: {{ .Values.useFipsEndpoint }}
 {{- end }}

--- a/charts/secrets-store-csi-driver-provider-aws/templates/daemonset.yaml
+++ b/charts/secrets-store-csi-driver-provider-aws/templates/daemonset.yaml
@@ -69,3 +69,12 @@ spec:
       affinity:
 {{ toYaml . | indent 8 }}
 {{- end }}
+{{- if .Values.secretsManagerClientConfig }}
+      env:
+        {{- range .Values.secretsManagerClientConfig }}
+        {{- if eq .name "AWS_USE_FIPS_ENDPOINT" }}
+        - name: {{ .name }}
+          value: {{ .value }}
+        {{- end }}
+        {{- end }}
+{{- end }}

--- a/charts/secrets-store-csi-driver-provider-aws/values.yaml
+++ b/charts/secrets-store-csi-driver-provider-aws/values.yaml
@@ -39,6 +39,4 @@ securityContext:
   privileged: false
   allowPrivilegeEscalation: false
 
-secretsManagerClientConfig:
-  - name: AWS_USE_FIPS_ENDPOINT
-    value: false
+useFipsEndpoint: false

--- a/charts/secrets-store-csi-driver-provider-aws/values.yaml
+++ b/charts/secrets-store-csi-driver-provider-aws/values.yaml
@@ -38,3 +38,7 @@ rbac:
 securityContext:
   privileged: false
   allowPrivilegeEscalation: false
+
+secretsManagerClientConfig:
+  - name: AWS_USE_FIPS_ENDPOINT
+    value: false


### PR DESCRIPTION
*Issue #:* https://github.com/aws/secrets-store-csi-driver-provider-aws/issues/141

*Description of changes:*

Allow users to turn on FIPS endpoint by adding additional flag to the install command `--set-json 'secretsManagerClientConfig=[{"name": "AWS_USE_FIPS_ENDPOINT", "value": true}]'`. The value of `AWS_USE_FIPS_ENDPOINT` will be passed to the CSI provider container as an environment variable. The underlying AWS SDK will read it automatically.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
