### PR TITLE
Helm: fix environment variables location

### DIFF
--- a/charts/secrets-store-csi-driver-provider-aws/templates/daemonset.yaml
+++ b/charts/secrets-store-csi-driver-provider-aws/templates/daemonset.yaml
@@ -49,6 +49,11 @@ spec:
             - name: mountpoint-dir
               mountPath: {{ .Values.kubeletPath }}/pods
               mountPropagation: HostToContainer
+          {{- if .Values.useFipsEndpoint }}
+          env:
+            - name: AWS_USE_FIPS_ENDPOINT
+              value: {{ .Values.useFipsEndpoint | quote }}
+          {{- end }}
       volumes:
         - name: providervol
           hostPath:
@@ -76,9 +81,4 @@ spec:
 {{- with .Values.affinity }}
       affinity:
 {{ toYaml . | indent 8 }}
-{{- end }}
-{{- if .Values.useFipsEndpoint }}
-      env:
-        - name: AWS_USE_FIPS_ENDPOINT
-          value: {{ .Values.useFipsEndpoint }}
 {{- end }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix daemonset.yaml to ensure that environment variables have to be set on container level

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
