### PR TITLE
add type: DirectoryOrCreate to the providervol volume definition

### DIFF
--- a/charts/secrets-store-csi-driver-provider-aws/templates/daemonset.yaml
+++ b/charts/secrets-store-csi-driver-provider-aws/templates/daemonset.yaml
@@ -58,6 +58,7 @@ spec:
         - name: providervol
           hostPath:
             path: {{ .Values.providerVolume }}
+            type: DirectoryOrCreate
         - name: mountpoint-dir
           hostPath:
             path: {{ .Values.kubeletPath }}/pods

--- a/deployment/aws-provider-installer.yaml
+++ b/deployment/aws-provider-installer.yaml
@@ -82,6 +82,7 @@ spec:
         - name: providervol
           hostPath:
             path: "/etc/kubernetes/secrets-store-csi-providers"
+            type: DirectoryOrCreate
         - name: mountpoint-dir
           hostPath:
             path: /var/lib/kubelet/pods


### PR DESCRIPTION
*Issue #, if available:*
# 345
*Description of changes:*
Adds `type: DirectoryOrCreate` to the `providervol` volume definition to avoid an issue when the provider pod starts before the driver pod

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
