### PR TITLE
Support passing the ARN for an SSM Parameter via objectName

### DIFF
--- a/provider/parameter_store_provider.go
+++ b/provider/parameter_store_provider.go
@@ -150,7 +150,13 @@ func (p *ParameterStoreProvider) fetchParameterStoreBatch(
 	// Build up the results from the batch
 	for _, parm := range rsp.Parameters {
 
-		descriptor := batchDesc[*(parm.Name)]
+		// The descriptor key will be either the Name or the ARN
+		var descriptor *SecretDescriptor
+		if batchDesc[*(parm.Name)] != nil {
+			descriptor = batchDesc[*(parm.Name)]
+		} else {
+			descriptor = batchDesc[*(parm.ARN)]
+		}
 
 		secretValue := &SecretValue{
 			Value:      []byte(*(parm.Value)),

--- a/tests/BasicTestMountSPC.yaml
+++ b/tests/BasicTestMountSPC.yaml
@@ -34,6 +34,11 @@ spec:
         - objectName: "ParameterStoreTestWithLongName"
           objectAlias: "ParameterStoreTest2"
           objectType: "ssmparameter"
+        - objectName: arn:aws:ssm:${REGION}:${ACCOUNT_NUMBER}:parameter/ParameterStoreTestWithARN
+          objectAlias: "ParameterStoreTest3"
+          failoverObject:
+            objectName: arn:aws:ssm:${FAILOVERREGION}:${ACCOUNT_NUMBER}:parameter/ParameterStoreTestWithARN
+          objectType: "ssmparameter"
         - objectName: "ParameterStoreRotationTest"
           objectType: "ssmparameter"
         - objectName: "SecretsManagerRotationTest"

--- a/tests/aws.bats
+++ b/tests/aws.bats
@@ -55,8 +55,10 @@ setup_file() {
  
    aws ssm put-parameter --name ParameterStoreTest1 --value ParameterStoreTest1Value --type SecureString --region $REGION
    aws ssm put-parameter --name ParameterStoreTestWithLongName --value ParameterStoreTest2Value --type SecureString --region $REGION
+   aws ssm put-parameter --name ParameterStoreTestWithARN --value ParameterStoreTest3Value --type SecureString --region $REGION
    aws ssm put-parameter --name ParameterStoreTest1 --value ParameterStoreTest1Value --type SecureString --region $FAILOVERREGION
    aws ssm put-parameter --name ParameterStoreTestWithLongName --value ParameterStoreTest2Value --type SecureString --region $FAILOVERREGION
+   aws ssm put-parameter --name ParameterStoreTestWithARN --value ParameterStoreTest3Value --type SecureString --region $FAILOVERREGION
  
    aws ssm put-parameter --name ParameterStoreRotationTest --value BeforeRotation --type SecureString --region $REGION
    aws secretsmanager create-secret --name SecretsManagerRotationTest --secret-string BeforeRotation --region $REGION
@@ -83,9 +85,11 @@ teardown_file() {
     aws secretsmanager delete-secret --secret-id SecretsManagerSync --force-delete-without-recovery --region $FAILOVERREGION
  
     aws ssm delete-parameter --name ParameterStoreTest1 --region $REGION
-    aws ssm delete-parameter --name ParameterStoreTestWithLongName --region $REGION 
+    aws ssm delete-parameter --name ParameterStoreTestWithLongName --region $REGION
+    aws ssm delete-parameter --name ParameterStoreTestWithARN --region $REGION
     aws ssm delete-parameter --name ParameterStoreTest1 --region $FAILOVERREGION
-    aws ssm delete-parameter --name ParameterStoreTestWithLongName --region $FAILOVERREGION 
+    aws ssm delete-parameter --name ParameterStoreTestWithLongName --region $FAILOVERREGION
+    aws ssm delete-parameter --name ParameterStoreTestWithARN --region $FAILOVERREGION
  
     aws ssm delete-parameter --name ParameterStoreRotationTest --region $REGION
     aws secretsmanager delete-secret --secret-id SecretsManagerRotationTest --force-delete-without-recovery --region $REGION
@@ -178,6 +182,9 @@ validate_jsme_mount() {
  
    result=$(kubectl --namespace $NAMESPACE exec $POD_NAME -- cat /mnt/secrets-store/ParameterStoreTest2)
    [[ "${result//$'\r'}" == "ParameterStoreTest2Value" ]]
+
+   result=$(kubectl --namespace $NAMESPACE exec $POD_NAME -- cat /mnt/secrets-store/ParameterStoreTest3)
+      [[ "${result//$'\r'}" == "ParameterStoreTest3Value" ]]
 }
  
  


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/secrets-store-csi-driver-provider-aws/issues/397

*Description of changes:*

The documentation states that you cannot pass an ARN for an object type of `ssmparameter`. This limitation seems to only be imposed by the fact that, after fetching the parameters from SSM, we only check if the parameter name matches one of the descriptors. However, the ARN is also available in the response for each parameter. As can be seen in the linked issue, the call to SSM doesn't fail, it is matching the result to the descriptor that fails due to a nil pointer.

This change falls back on the ARN if a descriptor is not matched by name. We can assume that if the parameter in the results was not found by name, then the ARN was passed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
