### PR TITLE
Updated Go code to follow language conventions

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -9,6 +9,7 @@ package auth
 
 import (
 	"context"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/request"

--- a/credential_provider/credential_provider_test.go
+++ b/credential_provider/credential_provider_test.go
@@ -3,6 +3,7 @@ package credential_provider
 import (
 	"context"
 	"fmt"
+
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
 	authv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -10,9 +11,9 @@ import (
 )
 
 const (
-	testNamespace        = "someNamespace"
-	testServiceAccount   = "someServiceAccount"
-	testRegion           = "someRegion"
+	testNamespace      = "someNamespace"
+	testServiceAccount = "someServiceAccount"
+	testRegion         = "someRegion"
 )
 
 // Mock STS client

--- a/credential_provider/irsa_credential_provider.go
+++ b/credential_provider/irsa_credential_provider.go
@@ -3,6 +3,7 @@ package credential_provider
 import (
 	"context"
 	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
@@ -116,7 +117,7 @@ func (p IRSACredentialProvider) getRoleARN() (arn *string, e error) {
 	roleArn := rsp.Annotations[arnAnno]
 	if len(roleArn) <= 0 {
 		klog.Errorf("Need IAM role for service account %s (namespace: %s) - %s", p.svcAcc, p.nameSpace, docURL)
-		return nil, fmt.Errorf("An IAM role must be associated with service account %s (namespace: %s)", p.svcAcc, p.nameSpace)
+		return nil, fmt.Errorf("an IAM role must be associated with service account %s (namespace: %s)", p.svcAcc, p.nameSpace)
 	}
 	klog.Infof("Role ARN for %s:%s is %s", p.nameSpace, p.svcAcc, roleArn)
 

--- a/credential_provider/irsa_credential_provider_test.go
+++ b/credential_provider/irsa_credential_provider_test.go
@@ -1,11 +1,12 @@
 package credential_provider
 
 import (
+	"strings"
+	"testing"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	k8sv1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	"strings"
-	"testing"
 )
 
 const (
@@ -54,7 +55,7 @@ type irsaCredentialTest struct {
 
 var irsaCredentialTests []irsaCredentialTest = []irsaCredentialTest{
 	{"IRSA Success", false, false, "fakeRoleARN", false, ""},
-	{"IRSA Missing Role", false, false, "", false, "An IAM role must"},
+	{"IRSA Missing Role", false, false, "", false, "an IAM role must"},
 	{"Fetch svc acc fail", true, false, "fakeRoleARN", false, "not found"},
 }
 
@@ -115,4 +116,3 @@ var irsaTokenTests []irsaCredentialTest = []irsaCredentialTest{
 	{"IRSA Token Success", false, false, "myRoleARN", true, ""},
 	{"IRSA Fetch JWT fail", false, true, "myRoleARN", true, "Fake create token"},
 }
-

--- a/credential_provider/pod_identity_credential_provider.go
+++ b/credential_provider/pod_identity_credential_provider.go
@@ -4,16 +4,17 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
-	"io"
 	authv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/klog/v2"
-	"net/http"
-	"strings"
-	"time"
 )
 
 const (

--- a/main.go
+++ b/main.go
@@ -73,7 +73,7 @@ func main() {
 		os.Remove(endpoint)
 	}()
 
-	providerSrv, err := server.NewServer(provider.NewSecretProviderFactory, clientset.CoreV1(), *driverWriteSecrets)
+	providerSrv, err := server.NewServer(provider.NewSecretProviderMappingGenerator, clientset.CoreV1(), *driverWriteSecrets)
 	if err != nil {
 		klog.Fatalf("Could not create server. error: %v", err)
 	}

--- a/provider/parameter_store_provider.go
+++ b/provider/parameter_store_provider.go
@@ -79,7 +79,7 @@ func (p *ParameterStoreProvider) fetchParameterStoreValue(
 ) (values []*SecretValue, err error) {
 
 	for _, client := range p.clients {
-		batchValues, err := p.fetchParameterStoreBatch(client, ctx, batchDescriptors, curMap)
+		batchValues, err := p.fetchParameterStoreBatch(ctx, client, batchDescriptors, curMap)
 
 		if utils.IsFatalError(err) {
 			return nil, err
@@ -92,7 +92,7 @@ func (p *ParameterStoreProvider) fetchParameterStoreValue(
 		}
 	}
 	if values == nil {
-		return nil, fmt.Errorf("Failed to fetch parameters from all regions.")
+		return nil, fmt.Errorf("failed to fetch parameters from all regions")
 	}
 
 	return values, nil
@@ -104,8 +104,8 @@ func (p *ParameterStoreProvider) fetchParameterStoreValue(
 // if any parameter is failed to fetch, the parameter is returned as invalid parameter
 // and the version information is updated in the current version map.
 func (p *ParameterStoreProvider) fetchParameterStoreBatch(
-	client ParameterStoreClient,
 	ctx context.Context,
+	client ParameterStoreClient,
 	batchDescriptors []*SecretDescriptor,
 	curMap map[string]*v1alpha1.ObjectVersion,
 ) (v []*SecretValue, err error) {
@@ -139,7 +139,7 @@ func (p *ParameterStoreProvider) fetchParameterStoreBatch(
 	}
 
 	if len(rsp.InvalidParameters) != 0 {
-		err = awserr.NewRequestFailure(awserr.New("", fmt.Sprintf("%s: Invalid parameters: %s", client.Region, strings.Join(aws.StringValueSlice(rsp.InvalidParameters), ", ")), err), 400, "")
+		err = awserr.NewRequestFailure(awserr.New("", fmt.Sprintf("%s: invalid parameters: %s", client.Region, strings.Join(aws.StringValueSlice(rsp.InvalidParameters), ", ")), err), 400, "")
 		return nil, err
 	}
 

--- a/provider/secret_descriptor_test.go
+++ b/provider/secret_descriptor_test.go
@@ -33,6 +33,7 @@ func TestGetSecretTypeSSM(t *testing.T) {
 }
 
 func RunDescriptorValidationTest(t *testing.T, descriptor *SecretDescriptor, expectedErrorMessage string) {
+	t.Helper()
 	err := descriptor.validateSecretDescriptor(singleRegion)
 	if err == nil || err.Error() != expectedErrorMessage {
 		t.Fatalf("Expected error: %s, got error: %v", expectedErrorMessage, err)
@@ -42,7 +43,7 @@ func RunDescriptorValidationTest(t *testing.T, descriptor *SecretDescriptor, exp
 func TestNoNamePresent(t *testing.T) {
 	descriptor := SecretDescriptor{}
 
-	expectedErrorMessage := "Object name must be specified"
+	expectedErrorMessage := "object name must be specified"
 
 	RunDescriptorValidationTest(t, &descriptor, expectedErrorMessage)
 }
@@ -54,7 +55,7 @@ func TestNoTypePresent(t *testing.T) {
 		ObjectName: objectName,
 	}
 
-	expectedErrorMessage := fmt.Sprintf("Invalid ARN format in object name: %s", objectName)
+	expectedErrorMessage := fmt.Sprintf("invalid ARN format in object name: %s", objectName)
 	RunDescriptorValidationTest(t, &descriptor, expectedErrorMessage)
 }
 
@@ -65,7 +66,7 @@ func TestUnknownService(t *testing.T) {
 		ObjectName: objectName,
 	}
 
-	expectedErrorMessage := fmt.Sprintf("Invalid service in ARN: sts")
+	expectedErrorMessage := "invalid service in ARN: sts"
 	RunDescriptorValidationTest(t, &descriptor, expectedErrorMessage)
 }
 
@@ -90,7 +91,7 @@ func TestNoObjectTypeWoArn(t *testing.T) {
 		ObjectName: objectName,
 	}
 
-	expectedErrorMessage := fmt.Sprintf("Must use objectType when a full ARN is not specified: %s", objectName)
+	expectedErrorMessage := fmt.Sprintf("must use objectType when a full ARN is not specified: %s", objectName)
 	RunDescriptorValidationTest(t, &descriptor, expectedErrorMessage)
 }
 
@@ -101,7 +102,7 @@ func TestInvalidObjectType(t *testing.T) {
 		ObjectType: objectType,
 	}
 
-	expectedErrorMessage := fmt.Sprintf("Invalid objectType: %s", objectType)
+	expectedErrorMessage := fmt.Sprintf("invalid objectType: %s", objectType)
 	RunDescriptorValidationTest(t, &descriptor, expectedErrorMessage)
 }
 
@@ -112,7 +113,7 @@ func TestSSMObjectType(t *testing.T) {
 		ObjectType: objectType,
 	}
 
-	expectedErrorMessage := fmt.Sprintf("Invalid objectType: %s", objectType)
+	expectedErrorMessage := fmt.Sprintf("invalid objectType: %s", objectType)
 	RunDescriptorValidationTest(t, &descriptor, expectedErrorMessage)
 }
 
@@ -150,7 +151,7 @@ func TestConflictingName(t *testing.T) {
           objectType: ssmparameter`
 
 	_, err := NewSecretDescriptorList("/", "", objects, singleRegion)
-	expectedErrorMessage := fmt.Sprintf("Name already in use for objectName: %s", "secret1")
+	expectedErrorMessage := fmt.Sprintf("name already in use for objectName: %s", "secret1")
 
 	if err == nil || err.Error() != expectedErrorMessage {
 		t.Fatalf("Expected error: %s, got error: %v", expectedErrorMessage, err)
@@ -168,7 +169,7 @@ func TestConflictingAlias(t *testing.T) {
             objectAlias: aliasOne`
 
 	_, err := NewSecretDescriptorList("/", "", objects, singleRegion)
-	expectedErrorMessage := fmt.Sprintf("Name already in use for objectAlias: %s", "aliasOne")
+	expectedErrorMessage := fmt.Sprintf("name already in use for objectAlias: %s", "aliasOne")
 
 	if err == nil || err.Error() != expectedErrorMessage {
 		t.Fatalf("Expected error: %s, got error: %v", expectedErrorMessage, err)
@@ -188,7 +189,7 @@ func TestConflictingAliasJMES(t *testing.T) {
                 objectAlias: aliasOne`
 
 	_, err := NewSecretDescriptorList("/", "", objects, singleRegion)
-	expectedErrorMessage := fmt.Sprintf("Name already in use for objectAlias: %s", "aliasOne")
+	expectedErrorMessage := fmt.Sprintf("name already in use for objectAlias: %s", "aliasOne")
 
 	if err == nil || err.Error() != expectedErrorMessage {
 		t.Fatalf("Expected error: %s, got error: %v", expectedErrorMessage, err)
@@ -204,7 +205,7 @@ func TestMissingAliasJMES(t *testing.T) {
               - path: .username`
 
 	_, err := NewSecretDescriptorList("/", "", objects, singleRegion)
-	expectedErrorMessage := fmt.Sprintf("Object alias must be specified for JMES object")
+	expectedErrorMessage := "object alias must be specified for JMES object"
 
 	if err == nil || err.Error() != expectedErrorMessage {
 		t.Fatalf("Expected error: %s, got error: %v", expectedErrorMessage, err)
@@ -220,14 +221,14 @@ func TestMissingPathJMES(t *testing.T) {
               - objectAlias: aliasOne`
 
 	_, err := NewSecretDescriptorList("/", "", objects, singleRegion)
-	expectedErrorMessage := fmt.Sprintf("Path must be specified for JMES object")
+	expectedErrorMessage := "path must be specified for JMES object"
 
 	if err == nil || err.Error() != expectedErrorMessage {
 		t.Fatalf("Expected error: %s, got error: %v", expectedErrorMessage, err)
 	}
 }
 
-//test separation/grouping into ssm/secretsmanager with valid parameters
+// test separation/grouping into ssm/secretsmanager with valid parameters
 func TestNewDescriptorList(t *testing.T) {
 	objects := `
           - objectName: secret1
@@ -259,7 +260,7 @@ func TestNewDescriptorList(t *testing.T) {
 
 }
 
-//test separation/grouping into ssm/secretsmanager with valid parameters
+// test separation/grouping into ssm/secretsmanager with valid parameters
 func TestBadYaml(t *testing.T) {
 	objects := `
           - objectName: secret1
@@ -272,7 +273,7 @@ func TestBadYaml(t *testing.T) {
 	}
 }
 
-//test separation/grouping into ssm/secretsmanager with valid parameters
+// test separation/grouping into ssm/secretsmanager with valid parameters
 func TestErrorYaml(t *testing.T) {
 	objects := `
           - objectName: secret1`
@@ -293,7 +294,7 @@ func TestEnumStrings(t *testing.T) {
 	}
 }
 
-//test separation/grouping into ssm/secretsmanager with valid parameters
+// test separation/grouping into ssm/secretsmanager with valid parameters
 func TestBadTrans(t *testing.T) {
 	objects := `
           - objectName: secret1
@@ -412,7 +413,7 @@ func TestNotTraversal(t *testing.T) {
 
 }
 
-//If the failoverObject exists, then the object must have an alias.
+// If the failoverObject exists, then the object must have an alias.
 func TestFallbackObjectRequiresAlias(t *testing.T) {
 	objects := `
     - objectName: "arn:aws:secretsmanager:us-west-1:123456789012:secret:secret1"
@@ -425,7 +426,7 @@ func TestFallbackObjectRequiresAlias(t *testing.T) {
 	}
 }
 
-//If either the main objectname or failoverObject's object name are not arns, then the objectType must be specified (failover is not ARN).
+// If either the main objectname or failoverObject's object name are not arns, then the objectType must be specified (failover is not ARN).
 func TestFallbackNonARNStillNeedsObjectType(t *testing.T) {
 	objects := `
     - objectName: "arn:aws:secretsmanager:us-west-1:123456789012:secret:secret1"
@@ -434,12 +435,12 @@ func TestFallbackNonARNStillNeedsObjectType(t *testing.T) {
     `
 	_, err := NewSecretDescriptorList("/mountpoint", "", objects, []string{"us-west-1", "us-west-2"})
 
-	if err == nil || !strings.Contains(err.Error(), "Must use objectType when a full ARN is not specified") {
+	if err == nil || !strings.Contains(err.Error(), "must use objectType when a full ARN is not specified") {
 		t.Fatalf("Unexpected error, got %v", err)
 	}
 }
 
-//If either the main objectname or failoverObject's object name are not arns, then the objectType must be specified (main objectName is not ARN).
+// If either the main objectname or failoverObject's object name are not arns, then the objectType must be specified (main objectName is not ARN).
 func TestBackupArnMustBePairedWithObjectType(t *testing.T) {
 	objects := `
     - objectName: "MySecret"
@@ -449,12 +450,12 @@ func TestBackupArnMustBePairedWithObjectType(t *testing.T) {
 
 	_, err := NewSecretDescriptorList("/mountpoint", "", objects, []string{"us-west-2", "us-west-1"})
 
-	if err == nil || !strings.Contains(err.Error(), "Must use objectType when a full ARN is not specified") {
+	if err == nil || !strings.Contains(err.Error(), "must use objectType when a full ARN is not specified") {
 		t.Fatalf("Unexpected error, got %v", err)
 	}
 }
 
-//If the failover descriptor is an ARN, and the objectType is specified, then they must match which provider to use.
+// If the failover descriptor is an ARN, and the objectType is specified, then they must match which provider to use.
 func TestBackupArnDoesNotMatchType(t *testing.T) {
 	objects := `
     - objectName: "arn:aws:secretsmanager:us-west-1:123456789012:secret:secret1"
@@ -469,7 +470,7 @@ func TestBackupArnDoesNotMatchType(t *testing.T) {
 	}
 }
 
-//The failoverObject must be a valid service name.
+// The failoverObject must be a valid service name.
 func TestBackupArnInvalidType(t *testing.T) {
 	objects := `
     - objectName: "arn:aws:secretsmanager:us-west-1:123456789012:secret:secret1"
@@ -478,12 +479,12 @@ func TestBackupArnInvalidType(t *testing.T) {
     `
 	_, err := NewSecretDescriptorList("/mountpoint", "", objects, []string{"us-west-1", "us-west-2"})
 
-	if err == nil || !strings.Contains(err.Error(), "Invalid service in ARN") {
+	if err == nil || !strings.Contains(err.Error(), "invalid service in ARN") {
 		t.Fatalf("Unexpected error, got %v", err)
 	}
 }
 
-//Success case: both ARNs match.
+// Success case: both ARNs match.
 func TestBackupArnSuccess(t *testing.T) {
 	objects := `
     - objectName: "arn:aws:secretsmanager:us-west-1:123456789012:secret:secret1"
@@ -497,7 +498,7 @@ func TestBackupArnSuccess(t *testing.T) {
 	}
 }
 
-//The main regions must now match.  This main ARN is for one region, and the main region is configured for a different one.
+// The main regions must now match.  This main ARN is for one region, and the main region is configured for a different one.
 func TestPrimaryArnRequiresRegionMatch(t *testing.T) {
 	objects := `
     - objectName: "arn:aws:secretsmanager:us-west-1:123456789012:secret:secret1"
@@ -510,7 +511,7 @@ func TestPrimaryArnRequiresRegionMatch(t *testing.T) {
 	}
 }
 
-//The failover regions must now match. This failover ARN is for one region, and failover region is configured for a different one.
+// The failover regions must now match. This failover ARN is for one region, and failover region is configured for a different one.
 func TestBackupArnRequiresRegionMatch(t *testing.T) {
 	objects := `
     - objectName: "arn:aws:secretsmanager:us-west-1:123456789012:secret:secret1"
@@ -524,7 +525,7 @@ func TestBackupArnRequiresRegionMatch(t *testing.T) {
 	}
 }
 
-//If a failoverObject is given, then a failover region must be given.
+// If a failoverObject is given, then a failover region must be given.
 func TestFallbackDataRequiresMultipleRegions(t *testing.T) {
 	objects := `
     - objectName: "arn:aws:secretsmanager:us-west-1:123456789012:secret:secret1"
@@ -538,7 +539,7 @@ func TestFallbackDataRequiresMultipleRegions(t *testing.T) {
 	}
 }
 
-//If using ssmparameter and a failoverObject, then using both objectVersion and objectVersionLabel is invalid
+// If using ssmparameter and a failoverObject, then using both objectVersion and objectVersionLabel is invalid
 func TestObjectVersionAndLabelAreIncompatible(t *testing.T) {
 	objects := `
     - objectName: "MySecret1"
@@ -556,7 +557,7 @@ func TestObjectVersionAndLabelAreIncompatible(t *testing.T) {
 	}
 }
 
-//Validate that the mountpoint still follows the objectAlias, even if multiple regions are defined.
+// Validate that the mountpoint still follows the objectAlias, even if multiple regions are defined.
 func TestGetPathForMultiregion(t *testing.T) {
 	objects := `
     - objectName: "MySecret1"
@@ -578,7 +579,7 @@ func TestGetPathForMultiregion(t *testing.T) {
 
 }
 
-//A few objectVersion tests. The two must be equal.
+// A few objectVersion tests. The two must be equal.
 func TestVersionIdsMustMatch(t *testing.T) {
 	objects := `
     - objectName: "MySecret1"
@@ -597,7 +598,7 @@ func TestVersionIdsMustMatch(t *testing.T) {
 	}
 }
 
-//Test Version Ids acceptibal if they match.
+// Test Version Ids acceptibal if they match.
 func TestVersionidsMatch(t *testing.T) {
 	objects := `
     - objectName: "MySecret1"

--- a/provider/secret_value.go
+++ b/provider/secret_value.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/jmespath/go-jmespath"
 )
 
@@ -13,8 +14,9 @@ type SecretValue struct {
 	Descriptor SecretDescriptor
 }
 
-func (p *SecretValue) String() string { return "<REDACTED>" } // Do not log secrets
-//parse out and return specified key value pairs from the secret
+func (p *SecretValue) String() string { return "<REDACTED>" } // Do not print secrets
+
+// parse out and return specified key value pairs from the secret
 func (p *SecretValue) getJsonSecrets() (s []*SecretValue, e error) {
 
 	jsonValues := make([]*SecretValue, 0)
@@ -25,7 +27,7 @@ func (p *SecretValue) getJsonSecrets() (s []*SecretValue, e error) {
 	var data interface{}
 	err := json.Unmarshal(p.Value, &data)
 	if err != nil {
-		return nil, fmt.Errorf("Invalid JSON used with jmesPath in secret: %s.", p.Descriptor.ObjectName)
+		return nil, fmt.Errorf("invalid JSON used with jmesPath in secret: %s", p.Descriptor.ObjectName)
 
 	}
 
@@ -35,18 +37,18 @@ func (p *SecretValue) getJsonSecrets() (s []*SecretValue, e error) {
 		jsonSecret, err := jmespath.Search(jmesPathEntry.Path, data)
 
 		if err != nil {
-			return nil, fmt.Errorf("Invalid JMES Path: %s.", jmesPathEntry.Path)
+			return nil, fmt.Errorf("invalid JMES Path: %s", jmesPathEntry.Path)
 		}
 
 		if jsonSecret == nil {
-			return nil, fmt.Errorf("JMES Path - %s for object alias - %s does not point to a valid object.",
+			return nil, fmt.Errorf("JMES Path - %s for object alias - %s does not point to a valid object",
 				jmesPathEntry.Path, jmesPathEntry.ObjectAlias)
 		}
 
 		jsonSecretAsString, isString := jsonSecret.(string)
 
 		if !isString {
-			return nil, fmt.Errorf("Invalid JMES search result type for path:%s. Only string is allowed.", jmesPathEntry.Path)
+			return nil, fmt.Errorf("invalid JMES search result type for path:%s. Only string is allowed", jmesPathEntry.Path)
 		}
 
 		descriptor := p.Descriptor.getJmesEntrySecretDescriptor(&jmesPathEntry)

--- a/provider/secret_value_test.go
+++ b/provider/secret_value_test.go
@@ -36,7 +36,7 @@ func TestNotValidJson(t *testing.T) {
 	path := ".username"
 	objectAlias := "test"
 	jsonContent := "NotValidJson"
-	expectedErrorMessage := fmt.Sprintf("Invalid JSON used with jmesPath in secret: %s.", TEST_OBJECT_NAME)
+	expectedErrorMessage := fmt.Sprintf("invalid JSON used with jmesPath in secret: %s", TEST_OBJECT_NAME)
 
 	RunGetJsonSecretTest(t, jsonContent, path, objectAlias, expectedErrorMessage)
 }
@@ -46,7 +46,7 @@ func TestJMESPathPointsToInvalidObject(t *testing.T) {
 	jsonContent := `{"username": "ParameterStoreUser", "password": "PasswordForParameterStore"}`
 	path := "testpath"
 	objectAlias := "testAlias"
-	expectedErrorMessage := fmt.Sprintf("JMES Path - %s for object alias - %s does not point to a valid object.", path, objectAlias)
+	expectedErrorMessage := fmt.Sprintf("JMES Path - %s for object alias - %s does not point to a valid object", path, objectAlias)
 
 	RunGetJsonSecretTest(t, jsonContent, path, objectAlias, expectedErrorMessage)
 }
@@ -56,7 +56,7 @@ func TestInvalidJMESPath(t *testing.T) {
 	jsonContent := `{"username": "ParameterStoreUser", "password": "PasswordForParameterStore"}`
 	path := ".testpath"
 	objectAlias := "testAlias"
-	expectedErrorMessage := fmt.Sprintf("Invalid JMES Path: %s.", path)
+	expectedErrorMessage := fmt.Sprintf("invalid JMES Path: %s", path)
 
 	RunGetJsonSecretTest(t, jsonContent, path, objectAlias, expectedErrorMessage)
 }
@@ -66,7 +66,7 @@ func TestInvalidJMESResultType(t *testing.T) {
 	jsonContent := `{"username": 3}`
 	path := "username"
 	objectAlias := "testAlias"
-	expectedErrorMessage := fmt.Sprintf("Invalid JMES search result type for path:%s. Only string is allowed.", path)
+	expectedErrorMessage := fmt.Sprintf("invalid JMES search result type for path:%s. Only string is allowed", path)
 
 	RunGetJsonSecretTest(t, jsonContent, path, objectAlias, expectedErrorMessage)
 }

--- a/provider/secrets_manager_provider.go
+++ b/provider/secrets_manager_provider.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -27,12 +27,11 @@ import (
 // versions (rotation reconciler case), this implementation will use the lower
 // latency DescribeSecret call to first determine if the secret has been
 // updated.
-//
 type SecretsManagerProvider struct {
 	clients []SecretsManagerClient
 }
 
-//SecretsManager client with region
+// SecretsManager client with region
 type SecretsManagerClient struct {
 	Region     string
 	Client     secretsmanageriface.SecretsManagerAPI
@@ -44,7 +43,6 @@ type SecretsManagerClient struct {
 // This method iterates over all descriptors and requests a fetch. When
 // sucessfully fetched, then it continues until all descriptors have been fetched.
 // Once an error happens, it immediately returns the error.
-//
 func (p *SecretsManagerProvider) GetSecretValues(
 	ctx context.Context,
 	descriptors []*SecretDescriptor,
@@ -66,8 +64,8 @@ func (p *SecretsManagerProvider) GetSecretValues(
 //
 // This method iterates over all available clients in the SecretsManagerProvider.
 // It requests a fetch from each of them.  Once a fetch succeeds it returns the
-//  value. If a fetch fails all clients it returns all errors.
 //
+//	value. If a fetch fails all clients it returns all errors.
 func (p *SecretsManagerProvider) fetchSecretManagerValue(
 	ctx context.Context,
 	descriptor *SecretDescriptor,
@@ -89,7 +87,7 @@ func (p *SecretsManagerProvider) fetchSecretManagerValue(
 		}
 	}
 	if len(value) == 0 {
-		return nil, fmt.Errorf("Failed to fetch secret from all regions: %s", descriptor.ObjectName)
+		return nil, fmt.Errorf("failed to fetch secret from all regions: %s", descriptor.ObjectName)
 	}
 
 	return value, nil
@@ -100,7 +98,6 @@ func (p *SecretsManagerProvider) fetchSecretManagerValue(
 // This method checks if the secret is current. If a secret is not current
 // (or this is the first time), the secret is fetched, added to the list of
 // secrets, and the version information is updated in the current version map.
-//
 func (p *SecretsManagerProvider) fetchSecretManagerValueWithClient(
 	ctx context.Context,
 	client SecretsManagerClient,
@@ -131,7 +128,7 @@ func (p *SecretsManagerProvider) fetchSecretManagerValueWithClient(
 	}
 	values = append(values, secret) // Build up the slice of values
 
-	//Fetch individual json key value pairs based on jmesPath
+	// Fetch individual json key value pairs based on jmesPath
 	jsonSecrets, jsonError := secret.getJsonSecrets()
 	if jsonError != nil {
 		return nil, jsonError
@@ -166,7 +163,6 @@ func (p *SecretsManagerProvider) fetchSecretManagerValueWithClient(
 // information is fetched using DescribeSecret and this method checks if the
 // current version is labeled as current (AWSCURRENT) or has the label
 // sepecified via objectVersionLable (if any).
-//
 func (p *SecretsManagerProvider) isCurrent(
 	ctx context.Context,
 	client SecretsManagerClient,
@@ -211,7 +207,6 @@ func (p *SecretsManagerProvider) isCurrent(
 //
 // This method builds up the GetSecretValue request using the objectName from
 // the request and any objectVersion or objectVersionLabel parameters.
-//
 func (p *SecretsManagerProvider) fetchSecret(
 	ctx context.Context,
 	client SecretsManagerClient,
@@ -249,10 +244,9 @@ func (p *SecretsManagerProvider) fetchSecret(
 // Private helper to refesh a secret from its previously stored value.
 //
 // Reads a secret back in from the file system.
-//
 func (p *SecretsManagerProvider) reloadSecret(descriptor *SecretDescriptor) (val *SecretValue, e error) {
 
-	sValue, err := ioutil.ReadFile(descriptor.GetMountPath())
+	sValue, err := os.ReadFile(descriptor.GetMountPath())
 	if err != nil {
 		return nil, err
 	}
@@ -261,7 +255,6 @@ func (p *SecretsManagerProvider) reloadSecret(descriptor *SecretDescriptor) (val
 }
 
 // Factory methods to build a new SecretsManagerProvider
-//
 func NewSecretsManagerProviderWithClients(clients ...SecretsManagerClient) *SecretsManagerProvider {
 	return &SecretsManagerProvider{
 		clients: clients,

--- a/server/server.go
+++ b/server/server.go
@@ -11,16 +11,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
 
-	"k8s.io/klog/v2"
-
 	"google.golang.org/grpc"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/secrets-store-csi-driver/provider/v1alpha1"
 
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -32,16 +30,16 @@ import (
 var Version string
 
 const (
-	namespaceAttrib      = "csi.storage.k8s.io/pod.namespace"
-	acctAttrib           = "csi.storage.k8s.io/serviceAccount.name"
-	podnameAttrib        = "csi.storage.k8s.io/pod.name"
-	regionAttrib         = "region"                        // The attribute name for the region in the SecretProviderClass
-	transAttrib          = "pathTranslation"               // Path translation char
-	regionLabel          = "topology.kubernetes.io/region" // The node label giving the region
-	secProvAttrib        = "objects"                       // The attribute used to pass the SecretProviderClass definition (with what to mount)
-	failoverRegionAttrib = "failoverRegion"                // The attribute name for the failover region in the SecretProviderClass
-	usePodIdentityAttrib = "usePodIdentity"                // The attribute used to indicate use Pod Identity for auth
-	preferredAddressTypeAttrib = "preferredAddressType"    // The attribute used to indicate IP address preference (IPv4 or IPv6) for network connections. It controls whether connecting to the Pod Identity Agent IPv4 or IPv6 endpoint.
+	namespaceAttrib            = "csi.storage.k8s.io/pod.namespace"
+	acctAttrib                 = "csi.storage.k8s.io/serviceAccount.name"
+	podnameAttrib              = "csi.storage.k8s.io/pod.name"
+	regionAttrib               = "region"                        // The attribute name for the region in the SecretProviderClass
+	transAttrib                = "pathTranslation"               // Path translation char
+	regionLabel                = "topology.kubernetes.io/region" // The node label giving the region
+	secProvAttrib              = "objects"                       // The attribute used to pass the SecretProviderClass definition (with what to mount)
+	failoverRegionAttrib       = "failoverRegion"                // The attribute name for the failover region in the SecretProviderClass
+	usePodIdentityAttrib       = "usePodIdentity"                // The attribute used to indicate use Pod Identity for auth
+	preferredAddressTypeAttrib = "preferredAddressType"          // The attribute used to indicate IP address preference (IPv4 or IPv6) for network connections. It controls whether connecting to the Pod Identity Agent IPv4 or IPv6 endpoint.
 )
 
 // A Secrets Store CSI Driver provider implementation for AWS Secrets Manager and SSM Parameter Store.
@@ -53,14 +51,14 @@ const (
 // during the mount of any one secret no secrets are written to the mount point.
 type CSIDriverProviderServer struct {
 	*grpc.Server
-	secretProviderFactory provider.ProviderFactoryFactory
+	secretProviderFactory provider.SecretProviderMappingGenerator
 	k8sClient             k8sv1.CoreV1Interface
 	driverWriteSecrets    bool
 }
 
-// Factory function to create the server to handle incoming mount requests.
+// NewServer creates a server instance that handles mount requests from the CSI driver
 func NewServer(
-	secretProviderFact provider.ProviderFactoryFactory,
+	secretProviderFact provider.SecretProviderMappingGenerator,
 	k8client k8sv1.CoreV1Interface,
 	driverWriteSecrets bool,
 ) (srv *CSIDriverProviderServer, e error) {
@@ -82,7 +80,7 @@ func (s *CSIDriverProviderServer) Mount(ctx context.Context, req *v1alpha1.Mount
 
 	// Basic sanity check
 	if len(req.GetTargetPath()) == 0 {
-		return nil, fmt.Errorf("Missing mount path")
+		return nil, fmt.Errorf("missing mount path")
 	}
 	mountDir := req.GetTargetPath()
 
@@ -117,7 +115,7 @@ func (s *CSIDriverProviderServer) Mount(ctx context.Context, req *v1alpha1.Mount
 		return nil, fmt.Errorf("failed to unmarshal file permission, error: %+v", err)
 	}
 
-	regions, err := s.getAwsRegions(region, failoverRegion, nameSpace, podName, ctx)
+	regions, err := s.getAwsRegions(ctx, region, failoverRegion, nameSpace, podName)
 	if err != nil {
 		klog.ErrorS(err, "Failed to initialize AWS session")
 		return nil, err
@@ -135,7 +133,7 @@ func (s *CSIDriverProviderServer) Mount(ctx context.Context, req *v1alpha1.Mount
 		}
 	}
 
-	awsSessions, err := s.getAwsSessions(nameSpace, svcAcct, ctx, regions, usePodIdentity, podName, preferredAddressType)
+	awsSessions, err := s.getAwsSessions(ctx, nameSpace, svcAcct, regions, usePodIdentity, podName, preferredAddressType)
 	if err != nil {
 		return nil, err
 	}
@@ -193,7 +191,7 @@ func (s *CSIDriverProviderServer) Mount(ctx context.Context, req *v1alpha1.Mount
 // If a region is not specified in the mount request, we must lookup the region from node label and add as primary region to the lookup region list
 // If both the region and node label region are not available, error will be thrown
 // If backupRegion is provided and is equal to region/node region, error will be thrown else backupRegion is added to the lookup region list
-func (s *CSIDriverProviderServer) getAwsRegions(region, backupRegion, nameSpace, podName string, ctx context.Context) (response []string, err error) {
+func (s *CSIDriverProviderServer) getAwsRegions(ctx context.Context, region, backupRegion, nameSpace, podName string) (response []string, err error) {
 	var lookupRegionList []string
 
 	// Find primary region.  Fall back to region node if unavailable.
@@ -220,7 +218,7 @@ func (s *CSIDriverProviderServer) getAwsRegions(region, backupRegion, nameSpace,
 // Gets the pod's AWS creds for each lookup region
 // Establishes the connection using Aws cred for each lookup region
 // If atleast one session is not created, error will be thrown
-func (s *CSIDriverProviderServer) getAwsSessions(nameSpace, svcAcct string, ctx context.Context, lookupRegionList []string, usePodIdentity bool, podName string, preferredAddressType string) (response []*session.Session, err error) {
+func (s *CSIDriverProviderServer) getAwsSessions(ctx context.Context, nameSpace, svcAcct string, lookupRegionList []string, usePodIdentity bool, podName string, preferredAddressType string) (response []*session.Session, err error) {
 	// Get the pod's AWS creds for each lookup region.
 	var awsSessionsList []*session.Session
 
@@ -276,7 +274,7 @@ func (s *CSIDriverProviderServer) getRegionFromNode(ctx context.Context, namespa
 	region := labels[regionLabel]
 
 	if len(region) == 0 {
-		return "", fmt.Errorf("Region not found")
+		return "", fmt.Errorf("region not found")
 	}
 
 	return region, nil
@@ -303,7 +301,7 @@ func (s *CSIDriverProviderServer) writeFile(secret *provider.SecretValue, mode o
 	}
 
 	// Write to a tempfile first
-	tmpFile, err := ioutil.TempFile(secret.Descriptor.GetMountDir(), secret.Descriptor.GetFileName())
+	tmpFile, err := os.CreateTemp(secret.Descriptor.GetMountDir(), secret.Descriptor.GetFileName())
 	if err != nil {
 		return nil, err
 	}

--- a/utils/error_handling_helper.go
+++ b/utils/error_handling_helper.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
-//Helper method to check if the request is fatal/4XX status
+// Helper method to check if the request is fatal/4XX status
 func IsFatalError(errMsg error) bool {
 
 	if reqErr, ok := errMsg.(awserr.RequestFailure); ok {


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Update Go code to follow language conventions
* sorted imports
* doc comments begin with func/method/struct/interface name
* errors are lowercased without punctuation suffix
* Got rid of deprecated `ioutil` calls in favor of replacements

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
