### PR TITLE
Organize Go imports

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,6 +19,14 @@ jobs:
           echo "Please format Go code by running: go fmt ./..."
           exit 1
         fi
+    - name: Go import lint
+      run: |
+        go install golang.org/x/tools/cmd/goimports@latest
+        if [ "$(goimports -d . | wc -l)" -gt 0 ]; then
+          goimports -d .
+          echo "Please format Go code by running: goimports -w ./"
+          exit 1
+        fi
     - name: Build
       run: go build -v ./...
     - name: Test

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -9,6 +9,7 @@ package auth
 
 import (
 	"context"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/request"

--- a/credential_provider/credential_provider_test.go
+++ b/credential_provider/credential_provider_test.go
@@ -3,6 +3,7 @@ package credential_provider
 import (
 	"context"
 	"fmt"
+
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
 	authv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/credential_provider/irsa_credential_provider.go
+++ b/credential_provider/irsa_credential_provider.go
@@ -3,6 +3,7 @@ package credential_provider
 import (
 	"context"
 	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"

--- a/credential_provider/irsa_credential_provider_test.go
+++ b/credential_provider/irsa_credential_provider_test.go
@@ -1,11 +1,12 @@
 package credential_provider
 
 import (
+	"strings"
+	"testing"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	k8sv1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	"strings"
-	"testing"
 )
 
 const (

--- a/credential_provider/pod_identity_credential_provider.go
+++ b/credential_provider/pod_identity_credential_provider.go
@@ -4,16 +4,17 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
-	"io"
 	authv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/klog/v2"
-	"net/http"
-	"strings"
-	"time"
 )
 
 const (

--- a/provider/secret_value.go
+++ b/provider/secret_value.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/jmespath/go-jmespath"
 )
 


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

This change can be replicated by running 
```
go install golang.org/x/tools/cmd/goimports@latest
goimports -format-only -w ./
```

I also added CI to enforce this change

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
