### PR TITLE
Use Go conventions on context.Context

### DIFF
--- a/provider/parameter_store_provider.go
+++ b/provider/parameter_store_provider.go
@@ -79,7 +79,7 @@ func (p *ParameterStoreProvider) fetchParameterStoreValue(
 ) (values []*SecretValue, err error) {
 
 	for _, client := range p.clients {
-		batchValues, err := p.fetchParameterStoreBatch(client, ctx, batchDescriptors, curMap)
+		batchValues, err := p.fetchParameterStoreBatch(ctx, client, batchDescriptors, curMap)
 
 		if utils.IsFatalError(err) {
 			return nil, err
@@ -104,8 +104,8 @@ func (p *ParameterStoreProvider) fetchParameterStoreValue(
 // if any parameter is failed to fetch, the parameter is returned as invalid parameter
 // and the version information is updated in the current version map.
 func (p *ParameterStoreProvider) fetchParameterStoreBatch(
-	client ParameterStoreClient,
 	ctx context.Context,
+	client ParameterStoreClient,
 	batchDescriptors []*SecretDescriptor,
 	curMap map[string]*v1alpha1.ObjectVersion,
 ) (v []*SecretValue, err error) {

--- a/server/server.go
+++ b/server/server.go
@@ -117,7 +117,7 @@ func (s *CSIDriverProviderServer) Mount(ctx context.Context, req *v1alpha1.Mount
 		return nil, fmt.Errorf("failed to unmarshal file permission, error: %+v", err)
 	}
 
-	regions, err := s.getAwsRegions(region, failoverRegion, nameSpace, podName, ctx)
+	regions, err := s.getAwsRegions(ctx, region, failoverRegion, nameSpace, podName)
 	if err != nil {
 		klog.ErrorS(err, "Failed to initialize AWS session")
 		return nil, err
@@ -135,7 +135,7 @@ func (s *CSIDriverProviderServer) Mount(ctx context.Context, req *v1alpha1.Mount
 		}
 	}
 
-	awsSessions, err := s.getAwsSessions(nameSpace, svcAcct, ctx, regions, usePodIdentity, podName, preferredAddressType)
+	awsSessions, err := s.getAwsSessions(ctx, nameSpace, svcAcct, regions, usePodIdentity, podName, preferredAddressType)
 	if err != nil {
 		return nil, err
 	}
@@ -193,7 +193,7 @@ func (s *CSIDriverProviderServer) Mount(ctx context.Context, req *v1alpha1.Mount
 // If a region is not specified in the mount request, we must lookup the region from node label and add as primary region to the lookup region list
 // If both the region and node label region are not available, error will be thrown
 // If backupRegion is provided and is equal to region/node region, error will be thrown else backupRegion is added to the lookup region list
-func (s *CSIDriverProviderServer) getAwsRegions(region, backupRegion, nameSpace, podName string, ctx context.Context) (response []string, err error) {
+func (s *CSIDriverProviderServer) getAwsRegions(ctx context.Context, region, backupRegion, nameSpace, podName string) (response []string, err error) {
 	var lookupRegionList []string
 
 	// Find primary region.  Fall back to region node if unavailable.
@@ -220,7 +220,7 @@ func (s *CSIDriverProviderServer) getAwsRegions(region, backupRegion, nameSpace,
 // Gets the pod's AWS creds for each lookup region
 // Establishes the connection using Aws cred for each lookup region
 // If atleast one session is not created, error will be thrown
-func (s *CSIDriverProviderServer) getAwsSessions(nameSpace, svcAcct string, ctx context.Context, lookupRegionList []string, usePodIdentity bool, podName string, preferredAddressType string) (response []*session.Session, err error) {
+func (s *CSIDriverProviderServer) getAwsSessions(ctx context.Context, nameSpace, svcAcct string, lookupRegionList []string, usePodIdentity bool, podName string, preferredAddressType string) (response []*session.Session, err error) {
 	// Get the pod's AWS creds for each lookup region.
 	var awsSessionsList []*session.Session
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2004,7 +2004,7 @@ func TestMounts(t *testing.T) {
 
 			// Do the mount
 			req := buildMountReq(dir, tst, []*v1alpha1.ObjectVersion{})
-			rsp, err := svr.Mount(nil, req)
+			rsp, err := svr.Mount(context.Background(), req)
 			if len(tst.expErr) == 0 && err != nil {
 				t.Fatalf("%s: Got unexpected error: %s", tst.testName, err)
 			}
@@ -2045,7 +2045,7 @@ func TestMountsNoWrite(t *testing.T) {
 
 			// Do the mount
 			req := buildMountReq(dir, tst, []*v1alpha1.ObjectVersion{})
-			rsp, err := svr.Mount(nil, req)
+			rsp, err := svr.Mount(context.Background(), req)
 			if len(tst.expErr) == 0 && err != nil {
 				t.Fatalf("%s: Got unexpected error: %s", tst.testName, err)
 			}
@@ -2468,7 +2468,7 @@ func TestReMounts(t *testing.T) {
 
 			// Do the mount
 			req := buildMountReq(dir, tst, curState)
-			rsp, err := svr.Mount(nil, req)
+			rsp, err := svr.Mount(context.Background(), req)
 			if len(tst.expErr) == 0 && err != nil {
 				t.Fatalf("%s: Got unexpected error: %s", tst.testName, err)
 			}
@@ -2510,7 +2510,7 @@ func TestNoWriteReMounts(t *testing.T) {
 
 			// Do the mount
 			req := buildMountReq(dir, tst, curState)
-			rsp, err := svr.Mount(nil, req)
+			rsp, err := svr.Mount(context.Background(), req)
 			if len(tst.expErr) == 0 && err != nil {
 				t.Fatalf("%s: Got unexpected error: %s", tst.testName, err)
 			}
@@ -2547,7 +2547,7 @@ func TestEmptyAttributes(t *testing.T) {
 		Permission:           "420",
 		CurrentObjectVersion: []*v1alpha1.ObjectVersion{},
 	}
-	rsp, err := svr.Mount(nil, req)
+	rsp, err := svr.Mount(context.Background(), req)
 
 	if rsp != nil {
 		t.Fatalf("TestEmptyAttributes: got unexpected response")
@@ -2567,7 +2567,7 @@ func TestNoPath(t *testing.T) {
 		Permission:           "420",
 		CurrentObjectVersion: []*v1alpha1.ObjectVersion{},
 	}
-	rsp, err := svr.Mount(nil, req)
+	rsp, err := svr.Mount(context.Background(), req)
 
 	if rsp != nil {
 		t.Fatalf("TestNoPath: got unexpected response")
@@ -2590,7 +2590,7 @@ func TestDriverVersion(t *testing.T) {
 		t.Fatalf("TestDriverVersion: got empty server")
 	}
 
-	ver, err := svr.Version(nil, &v1alpha1.VersionRequest{})
+	ver, err := svr.Version(context.Background(), &v1alpha1.VersionRequest{})
 	if err != nil {
 		t.Fatalf("TestDriverVersion: got unexpected error %s", err.Error())
 	}


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Go has strong convention around passing context.Context as the first call to functions. This is called out in the [context package documentation](https://pkg.go.dev/context)

> The Context should be the first parameter, typically named ctx:
> ```
> func DoSomething(ctx context.Context, arg Arg) error {
>	// ... use ctx ...
> }
> ```
> Do not pass a nil [Context](https://pkg.go.dev/context#Context), even if a function permits it. Pass [context.TODO](https://pkg.go.dev/context#TODO) if you are unsure about which Context to use.

  
I intentionally did not fix `auth/` and `credential_provider/` misuses of context, as that will be fixed in a later PR updating the AWS Go SDK.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
