### PR TITLE
Add support for driver-writes-secrets flag in Helm chart

### DIFF
--- a/charts/secrets-store-csi-driver-provider-aws/templates/daemonset.yaml
+++ b/charts/secrets-store-csi-driver-provider-aws/templates/daemonset.yaml
@@ -31,6 +31,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --provider-volume={{ .Values.providerVolume }}
+            {{- if .Values.driverWritesSecrets }}
+            - --driver-writes-secrets=true
+            {{- end }}
             {{- if .Values.k8sThrottlingParams }}
             {{- if .Values.k8sThrottlingParams.qps }}
             - --qps={{ .Values.k8sThrottlingParams.qps }}

--- a/charts/secrets-store-csi-driver-provider-aws/values.yaml
+++ b/charts/secrets-store-csi-driver-provider-aws/values.yaml
@@ -8,6 +8,8 @@ fullnameOverride: ""
 providerVolume: "/etc/kubernetes/secrets-store-csi-providers"
 kubeletPath: "/var/lib/kubelet"
 
+driverWritesSecrets: false
+
 podLabels: {}
 podAnnotations: {}
 


### PR DESCRIPTION
*Closes #337*

*Description of changes:*
This PR adds support for the `driver-writes-secrets` flag in the Helm chart.

Changes:
- Added `driverWritesSecrets` configuration option in values.yaml
- Updated daemonset.yaml to use the new option

This flag is particularly important for self-hosted non-EKS clusters.

Testing Done:
- Tested with flag enabled and disabled (helm install with and without the flag)
- Verified flag is correctly passed to pods when enabled
- Verified default behavior remains unchanged

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
