### PR TITLE
fix: make secret descriptor validation more granular (#95)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,11 +30,12 @@ Contributions via pull requests are much appreciated. Before sending us a pull r
 To send us a pull request, please:
 
 1. Fork the repository.
-2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
-3. Ensure local tests pass.
-4. Commit to your fork using clear commit messages.
-5. Send us a pull request, answering any default questions in the pull request interface.
-6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
+2. Modify the source; please focus on the specific change you are contributing. 
+3. Run `gofmt` to ensure consistent formatting.
+4. Ensure local tests pass.
+5. Commit to your fork using clear commit messages.
+6. Send us a pull request, answering any default questions in the pull request interface.
+7. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 
 GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).

--- a/provider/secret_descriptor.go
+++ b/provider/secret_descriptor.go
@@ -468,7 +468,7 @@ func NewSecretDescriptorList(mountDir, translate, objectSpec string, regions []s
 
 		for _, jmesPathEntry := range descriptor.JMESPath {
 			if seenAliases[jmesPathEntry.ObjectAlias] {
-				return nil, fmt.Errorf("found duplicate object alias %s in JMES path entry %s", jmesPathEntry.ObjectAlias, jmesPathEntry.Path)
+				return nil, fmt.Errorf("Name already in use for objectAlias: found duplicate object alias %s in JMES path entry %s", jmesPathEntry.ObjectAlias, jmesPathEntry.Path)
 			}
 			seenAliases[jmesPathEntry.ObjectAlias] = true
 		}

--- a/provider/secret_descriptor_test.go
+++ b/provider/secret_descriptor_test.go
@@ -325,7 +325,7 @@ func TestConflictingAliasJMES(t *testing.T) {
                 objectAlias: aliasOne`
 
 	_, err := NewSecretDescriptorList("/", "", objects, singleRegion)
-	expectedErrorMessage := fmt.Sprintf("found duplicate object alias %s in JMES path entry %s", "aliasOne", ".username")
+	expectedErrorMessage := fmt.Sprintf("Name already in use for objectAlias: found duplicate object alias %s in JMES path entry %s", "aliasOne", ".username")
 
 	if err == nil || err.Error() != expectedErrorMessage {
 		t.Fatalf("Expected error: %s, got error: %v", expectedErrorMessage, err)

--- a/provider/secret_descriptor_test.go
+++ b/provider/secret_descriptor_test.go
@@ -142,7 +142,7 @@ func TestSSMBothVersionandLabel(t *testing.T) {
 	RunDescriptorValidationTest(t, &descriptor, expectedErrorMessage)
 }
 
-// Conflicting name; alias and version label not present -- should throw
+// Conflicting name; alias and version label not present -- should throw (case 4)
 func TestConflictingNameWoAliasAndVersionLabel(t *testing.T) {
 	objects :=
 		`
@@ -159,7 +159,7 @@ func TestConflictingNameWoAliasAndVersionLabel(t *testing.T) {
 	}
 }
 
-// Conflicting name and alias; version label not present -- should throw
+// Conflicting name and alias; version label not present -- should throw (case 1)
 func TestConflictingNameAndAliasWoVersionLabel(t *testing.T) {
 	objects :=
 		`
@@ -237,7 +237,7 @@ func TestConflictingNameAndNotAliasWithVersionLabel(t *testing.T) {
 	}
 }
 
-// Conflicting name and version label; alias not present -- should throw
+// Conflicting name and version label; alias not present -- should throw (case 2)
 func TestConflictingNameAndVersionLabelWoAlias(t *testing.T) {
 	objects :=
 		`
@@ -250,6 +250,27 @@ func TestConflictingNameAndVersionLabelWoAlias(t *testing.T) {
 
 	_, err := NewSecretDescriptorList("/", "", objects, singleRegion)
 	expectedErrorMessage := fmt.Sprintf("found descriptor with duplicate object name %s, no object alias, and duplicate version label %s", "secret1", "AWSCURRENT")
+
+	if err == nil || err.Error() != expectedErrorMessage {
+		t.Fatalf("Expected error: %s, got error: %v", expectedErrorMessage, err)
+	}
+}
+
+// Conflicting name, alias, and version label -- should throw (case 3)
+func TestConflictingNameAndVersionLabelAndAlias(t *testing.T) {
+	objects :=
+		`
+        - objectName: secret1
+          objectAlias: aliasOne
+          objectVersionLabel: AWSCURRENT
+          objectType: ssmparameter
+        - objectName: secret1
+          objectAlias: aliasOne
+          objectVersionLabel: AWSCURRENT
+          objectType: ssmparameter`
+
+	_, err := NewSecretDescriptorList("/", "", objects, singleRegion)
+	expectedErrorMessage := fmt.Sprintf("found descriptor with duplicate object name %s, duplicate object alias %s, and duplicate version label %s", "secret1", "aliasOne", "AWSCURRENT")
 
 	if err == nil || err.Error() != expectedErrorMessage {
 		t.Fatalf("Expected error: %s, got error: %v", expectedErrorMessage, err)

--- a/provider/secret_descriptor_test.go
+++ b/provider/secret_descriptor_test.go
@@ -152,7 +152,7 @@ func TestConflictingNameWoAliasAndVersionLabel(t *testing.T) {
           objectType: ssmparameter`
 
 	_, err := NewSecretDescriptorList("/", "", objects, singleRegion)
-	expectedErrorMessage := fmt.Sprintf("found descriptor with duplicate object name %s with no object alias or version label", "secret1")
+	expectedErrorMessage := fmt.Sprintf("found descriptor with duplicate object name %s, no object alias, and no version label", "secret1")
 
 	if err == nil || err.Error() != expectedErrorMessage {
 		t.Fatalf("Expected error: %s, got error: %v", expectedErrorMessage, err)
@@ -171,7 +171,7 @@ func TestConflictingNameAndAliasWoVersionLabel(t *testing.T) {
           objectType: ssmparameter`
 
 	_, err := NewSecretDescriptorList("/", "", objects, singleRegion)
-	expectedErrorMessage := fmt.Sprintf("found descriptor with duplicate object name %s and object alias %s with no version label", "secret1", "aliasOne")
+	expectedErrorMessage := fmt.Sprintf("found descriptor with duplicate object name %s, duplicate object alias %s, and no version label", "secret1", "aliasOne")
 
 	if err == nil || err.Error() != expectedErrorMessage {
 		t.Fatalf("Expected error: %s, got error: %v", expectedErrorMessage, err)
@@ -249,7 +249,7 @@ func TestConflictingNameAndVersionLabelWoAlias(t *testing.T) {
           objectType: ssmparameter`
 
 	_, err := NewSecretDescriptorList("/", "", objects, singleRegion)
-	expectedErrorMessage := fmt.Sprintf("found descriptor with duplicate object name %s and version label %s with no object alias", "secret1", "AWSCURRENT")
+	expectedErrorMessage := fmt.Sprintf("found descriptor with duplicate object name %s, no object alias, and duplicate version label %s", "secret1", "AWSCURRENT")
 
 	if err == nil || err.Error() != expectedErrorMessage {
 		t.Fatalf("Expected error: %s, got error: %v", expectedErrorMessage, err)


### PR DESCRIPTION
*Issue #, if available:*
#95 

*Description of changes:*
- Make secret descriptor validation more granular to account for edge cases as in #95 
- Add tests for various combinations of conflicting `objectName`s, `objectAlias`es, and `objectVersionLabel`s 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
