### PR TITLE
Improved Error Message for Secret Key Retrieval Failures

### DIFF
--- a/provider/secrets_manager_provider.go
+++ b/provider/secrets_manager_provider.go
@@ -87,7 +87,7 @@ func (p *SecretsManagerProvider) fetchSecretManagerValue(
 		}
 	}
 	if len(value) == 0 {
-		return nil, fmt.Errorf("Failed to fetch secret from all regions: %s", descriptor.ObjectName)
+		return nil, fmt.Errorf("Failed to fetch secret from all regions. Verify secret exists and required permissions are granted for: %s", descriptor.ObjectName)
 	}
 
 	return value, nil

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1095,8 +1095,8 @@ var mountTestsForMultiRegion []testCase = []testCase{
 		brReqErr: awserr.NewRequestFailure(
 			awserr.New(secretsmanager.ErrCodeInternalServiceError, "An error occurred on the server side.", fmt.Errorf("")),
 			500, ""),
-		expErr:     "Failed to fetch secret from all regions",
-		brExpErr:   "Failed to fetch secret from all regions:",
+		expErr:     "Failed to fetch secret from all regions. Verify secret exists and required permissions are granted for",
+		brExpErr:   "Failed to fetch secret from all regions. Verify secret exists and required permissions are granted for:",
 		expSecrets: map[string]string{},
 		perms:      "420",
 	},


### PR DESCRIPTION
*Issue #, if available:*
#401 

*Description of changes:*

Updated the error message to provide clearer debugging information when fetching secrets. Previously, the message "Failed to fetch secret from all regions" was misleading, as it did not give enough information. This often led to unnecessary debugging efforts . The new message, "Failed to fetch secret from all regions. Verify secret exists and required permissions are granted," explicitly guides users to check both the existence of the secret and its required permissions, reducing confusion and improving troubleshooting efficiency

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
