### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,5 @@ The following table lists the configurable parameters of the csi-secrets-store-p
 | `podAnnotations` | Additional pod annotations| `{}` |
 | `updateStrategy` | Configure a custom update strategy for the daemonset on nodes | `RollingUpdate`|
 | `rbac.install` | Install default service account | true |
+| `priorityClassName` | Indicates the importance of a Pod relative to other Pods| `""` |
+


### PR DESCRIPTION
Add priorityClassName in the configuration table. ideally the default value should be set to system-node-critical to allow the daemonSet pod to be scheduled to new node before application pod which may have a dependency on the ASCP.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
