### PR TITLE
Updated to the latest default volume mount

### DIFF
--- a/charts/secrets-store-csi-driver-provider-aws/values.yaml
+++ b/charts/secrets-store-csi-driver-provider-aws/values.yaml
@@ -6,7 +6,7 @@ image:
 awsRegion: ""
 nameOverride: ""
 fullnameOverride: ""
-providerVolume: "/etc/kubernetes/secrets-store-csi-providers"
+providerVolume: "/var/run/secrets-store-csi-providers"
 kubeletPath: "/var/lib/kubelet"
 
 driverWritesSecrets: false

--- a/deployment/aws-provider-installer.yaml
+++ b/deployment/aws-provider-installer.yaml
@@ -61,7 +61,7 @@ spec:
           image: public.ecr.aws/aws-secrets-manager/secrets-store-csi-driver-provider-aws:1.0.r2-80-g8244505-2025.02.10.18.44
           imagePullPolicy: Always
           args:
-              - --provider-volume=/etc/kubernetes/secrets-store-csi-providers
+              - --provider-volume=/var/run/secrets-store-csi-providers
           resources:
             requests:
               cpu: 50m
@@ -73,7 +73,7 @@ spec:
             privileged: false
             allowPrivilegeEscalation: false
           volumeMounts:
-            - mountPath: "/etc/kubernetes/secrets-store-csi-providers"
+            - mountPath: "/var/run/secrets-store-csi-providers"
               name: providervol
             - name: mountpoint-dir
               mountPath: /var/lib/kubelet/pods
@@ -81,7 +81,7 @@ spec:
       volumes:
         - name: providervol
           hostPath:
-            path: "/etc/kubernetes/secrets-store-csi-providers"
+            path: "/var/run/secrets-store-csi-providers"
         - name: mountpoint-dir
           hostPath:
             path: /var/lib/kubelet/pods

--- a/deployment/private-installer.yaml
+++ b/deployment/private-installer.yaml
@@ -61,7 +61,7 @@ spec:
           image: ${PRIVREPO}:latest
           imagePullPolicy: Always
           args:
-              - --provider-volume=/etc/kubernetes/secrets-store-csi-providers
+              - --provider-volume=/var/run/secrets-store-csi-providers
               - --driver-writes-secrets=false
           resources:
             requests:
@@ -74,7 +74,7 @@ spec:
             privileged: false
             allowPrivilegeEscalation: false
           volumeMounts:
-            - mountPath: "/etc/kubernetes/secrets-store-csi-providers"
+            - mountPath: "/var/run/secrets-store-csi-providers"
               name: providervol
             - name: mountpoint-dir
               mountPath: /var/lib/kubelet/pods
@@ -82,7 +82,7 @@ spec:
       volumes:
         - name: providervol
           hostPath:
-            path: "/etc/kubernetes/secrets-store-csi-providers"
+            path: "/var/run/secrets-store-csi-providers"
         - name: mountpoint-dir
           hostPath:
             path: /var/lib/kubelet/pods

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	endpointDir        = flag.String("provider-volume", "/etc/kubernetes/secrets-store-csi-providers", "Rendezvous directory for provider socket")
+	endpointDir        = flag.String("provider-volume", "/var/run/secrets-store-csi-providers", "Rendezvous directory for provider socket")
 	driverWriteSecrets = flag.Bool("driver-writes-secrets", false, "The driver will do the write instead of the plugin")
 	qps                = flag.Int("qps", 5, "Maximum query per second to the Kubernetes API server. To mount the requested secret on the pod, the AWS CSI provider lookups the region of the pod and the role ARN associated with the service account by calling the K8s APIs. Increase the value if the provider is throttled by client-side limit to the API server.")
 	burst              = flag.Int("burst", 10, "Maximum burst for throttle. To mount the requested secret on the pod, the AWS CSI provider lookups the region of the pod and the role ARN associated with the service account by calling the K8s APIs. Increase the value if the provider is throttled by client-side limit to the API server.")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updated and tested the new default volume mount to /var/run/secrets-store-csi-providers. 
Related Issue : https://github.com/aws/secrets-store-csi-driver-provider-aws/issues/152

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
