### PR TITLE
fix: change http timeout for pod identity from 100ms to 10s

### DIFF
--- a/credential_provider/pod_identity_credential_provider.go
+++ b/credential_provider/pod_identity_credential_provider.go
@@ -20,7 +20,7 @@ const (
 	podIdentityAudience   = "pods.eks.amazonaws.com"
 	defaultIPv4Endpoint   = "http://169.254.170.23/v1/credentials"
 	defaultIPv6Endpoint   = "http://[fd00:ec2::23]/v1/credentials"
-	httpTimeout           = 100 * time.Millisecond
+	httpTimeout           = time.Second * 10
 	podIdentityAuthHeader = "Authorization"
 )
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The 100ms hard-coded timeout set for the pod identity HTTP client is too short and may cause issues with volume mounting in certain scenarios, especially in regions without the eks-auth VPCE. When the driver encounters a cancel error, it often requires complex debugging to identify the specific cause, which is not user-friendly. This PR adjusts the timeout to 10s to prevent such issues.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.