### PR TITLE
chore(helm-chart): add commonLabels property

### DIFF
--- a/charts/secrets-store-csi-driver-provider-aws/templates/_helpers.tpl
+++ b/charts/secrets-store-csi-driver-provider-aws/templates/_helpers.tpl
@@ -41,6 +41,7 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app: {{ template "provider.name" . }}
+{{ toYaml .Values.commonLabels }}
 {{- end }}
 
 {{/*

--- a/charts/secrets-store-csi-driver-provider-aws/values.yaml
+++ b/charts/secrets-store-csi-driver-provider-aws/values.yaml
@@ -11,6 +11,7 @@ kubeletPath: "/var/lib/kubelet"
 
 driverWritesSecrets: false
 
+commonLabels: {}
 podLabels: {}
 podAnnotations: {}
 


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* Adds a (fairly standard) `commonLabels` property to the Helm chart to allow users to define labels across all created resources. One example use case is putting labels denoting team ownership, which is often desirable to require at resource creation time.

I've tested this with and without `commonLabels` set to a value, and the output is as expected in both cases.

`helm template .` with `commonLabels: { }` (as in PR; truncated long resources for brevity):

```yaml
---
# Source: secrets-store-csi-driver-provider-aws/templates/rbac.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: release-name-secrets-store-csi-driver-provider-aws
  namespace: default
  labels:
    helm.sh/chart: secrets-store-csi-driver-provider-aws-1.0.1
    app.kubernetes.io/name: secrets-store-csi-driver-provider-aws
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    app: secrets-store-csi-driver-provider-aws
---
# Source: secrets-store-csi-driver-provider-aws/templates/rbac.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: release-name-secrets-store-csi-driver-provider-aws-cluster-role
  labels:
    helm.sh/chart: secrets-store-csi-driver-provider-aws-1.0.1
    app.kubernetes.io/name: secrets-store-csi-driver-provider-aws
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    app: secrets-store-csi-driver-provider-aws
...
---
# Source: secrets-store-csi-driver-provider-aws/templates/rbac.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: release-name-secrets-store-csi-driver-provider-aws-cluster-role-binding
  labels:
    helm.sh/chart: secrets-store-csi-driver-provider-aws-1.0.1
    app.kubernetes.io/name: secrets-store-csi-driver-provider-aws
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    app: secrets-store-csi-driver-provider-aws
...
---
# Source: secrets-store-csi-driver-provider-aws/templates/daemonset.yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  namespace: default
  name: release-name-secrets-store-csi-driver-provider-aws
  labels:
    helm.sh/chart: secrets-store-csi-driver-provider-aws-1.0.1
    app.kubernetes.io/name: secrets-store-csi-driver-provider-aws
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    app: secrets-store-csi-driver-provider-aws
spec:
  updateStrategy:
    type: RollingUpdate
  selector:
    matchLabels:
      app: secrets-store-csi-driver-provider-aws
  template:
    metadata:
      labels:
        helm.sh/chart: secrets-store-csi-driver-provider-aws-1.0.1
        app.kubernetes.io/name: secrets-store-csi-driver-provider-aws
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/managed-by: Helm
        app: secrets-store-csi-driver-provider-aws
    spec:
      ...
```

`helm template .` with `commonLabels: { frogs: true }` (truncated long resources for brevity):

```yaml
---
# Source: secrets-store-csi-driver-provider-aws/templates/rbac.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: release-name-secrets-store-csi-driver-provider-aws
  namespace: default
  labels:
    helm.sh/chart: secrets-store-csi-driver-provider-aws-1.0.1
    app.kubernetes.io/name: secrets-store-csi-driver-provider-aws
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    app: secrets-store-csi-driver-provider-aws
    frogs: true
---
# Source: secrets-store-csi-driver-provider-aws/templates/rbac.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: release-name-secrets-store-csi-driver-provider-aws-cluster-role
  labels:
    helm.sh/chart: secrets-store-csi-driver-provider-aws-1.0.1
    app.kubernetes.io/name: secrets-store-csi-driver-provider-aws
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    app: secrets-store-csi-driver-provider-aws
    frogs: true
...
---
# Source: secrets-store-csi-driver-provider-aws/templates/rbac.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: release-name-secrets-store-csi-driver-provider-aws-cluster-role-binding
  labels:
    helm.sh/chart: secrets-store-csi-driver-provider-aws-1.0.1
    app.kubernetes.io/name: secrets-store-csi-driver-provider-aws
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    app: secrets-store-csi-driver-provider-aws
    frogs: true
...
---
# Source: secrets-store-csi-driver-provider-aws/templates/daemonset.yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  namespace: default
  name: release-name-secrets-store-csi-driver-provider-aws
  labels:
    helm.sh/chart: secrets-store-csi-driver-provider-aws-1.0.1
    app.kubernetes.io/name: secrets-store-csi-driver-provider-aws
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    app: secrets-store-csi-driver-provider-aws
    frogs: true
spec:
  updateStrategy:
    type: RollingUpdate
  selector:
    matchLabels:
      app: secrets-store-csi-driver-provider-aws
  template:
    metadata:
      labels:
        helm.sh/chart: secrets-store-csi-driver-provider-aws-1.0.1
        app.kubernetes.io/name: secrets-store-csi-driver-provider-aws
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/managed-by: Helm
        app: secrets-store-csi-driver-provider-aws
        frogs: true
    spec:
      ...
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.