### PR TITLE
Implement auto-fallback for IPv4/IPv6 in PodIdentityCredentialProvider

### DIFF
--- a/credential_provider/pod_identity_credential_provider.go
+++ b/credential_provider/pod_identity_credential_provider.go
@@ -113,27 +113,30 @@ func parseAddressPreference(preferredAddressType string) string {
 }
 
 func (p *PodIdentityCredentialProvider) GetAWSConfig(ctx context.Context) (aws.Config, error) {
+	var configErr error
 	preference := parseAddressPreference(p.preferredAddressType)
 	if preference == "auto" || preference == "ipv4" {
 		config, err := p.getConfigWithEndpoint(ctx, podIdentityAgentEndpointIPv4)
 		if err != nil {
 			klog.Warningf("IPv4 endpoint attempt failed: %v", err)
+			configErr = err
 		} else {
 			return config, nil
 		}
 	}
 
-	if preference == "ipv6" || preference == "auto" {
+	if preference == "auto" || preference == "ipv6" {
 		config, err := p.getConfigWithEndpoint(ctx, podIdentityAgentEndpointIPv6)
 
 		if err != nil {
-			klog.Warningf("IPv4 endpoint attempt failed: %v", err)
+			klog.Warningf("IPv6 endpoint attempt failed: %v", err)
+			configErr = err
 		} else {
 			return config, nil
 		}
 	}
 
-	return aws.Config{}, fmt.Errorf("failed to get AWS config %s", p.preferredAddressType)
+	return aws.Config{}, fmt.Errorf("failed to get AWS config from pod identity agent: %+v", configErr)
 }
 
 func (p *PodIdentityCredentialProvider) getConfigWithEndpoint(ctx context.Context, endpoint string) (aws.Config, error) {

--- a/credential_provider/pod_identity_credential_provider.go
+++ b/credential_provider/pod_identity_credential_provider.go
@@ -2,10 +2,10 @@ package credential_provider
 
 import (
 	"context"
+	"fmt"
+	"k8s.io/klog/v2"
 	"net/http"
 	"time"
-	"fmt"
-    "k8s.io/klog/v2"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -69,74 +69,74 @@ func (p *podIdentityTokenFetcher) GetToken() (string, error) {
 
 // PodIdentityCredentialProvider implements CredentialProvider using pod identity
 type PodIdentityCredentialProvider struct {
-	region             string
+	region               string
 	preferredAddressType string
-	fetcher            endpointcreds.AuthTokenProvider
-	httpClient         *http.Client
+	fetcher              endpointcreds.AuthTokenProvider
+	httpClient           *http.Client
 }
 
 func NewPodIdentityCredentialProvider(
-    region, nameSpace, svcAcc, podName, preferredAddressType string,
-    k8sClient k8sv1.CoreV1Interface,
+	region, nameSpace, svcAcc, podName, preferredAddressType string,
+	k8sClient k8sv1.CoreV1Interface,
 ) (ConfigProvider, error) {
-    // Add validation if needed
-    if region == "" {
-        return nil, fmt.Errorf("region cannot be empty")
-    }
-    if k8sClient == nil {
-        return nil, fmt.Errorf("k8s client cannot be nil")
-    }
-    
-    return &PodIdentityCredentialProvider{
-        region:               region,
-        preferredAddressType: preferredAddressType,
-        fetcher:             newPodIdentityTokenFetcher(nameSpace, svcAcc, podName, k8sClient),
-        httpClient:          &http.Client{
-            Timeout: httpTimeout,
-        },
-    }, nil
+	// Add validation if needed
+	if region == "" {
+		return nil, fmt.Errorf("region cannot be empty")
+	}
+	if k8sClient == nil {
+		return nil, fmt.Errorf("k8s client cannot be nil")
+	}
+
+	return &PodIdentityCredentialProvider{
+		region:               region,
+		preferredAddressType: preferredAddressType,
+		fetcher:              newPodIdentityTokenFetcher(nameSpace, svcAcc, podName, k8sClient),
+		httpClient: &http.Client{
+			Timeout: httpTimeout,
+		},
+	}, nil
 }
 
 func parseAddressPreference(preferredAddressType string) string {
-    if preferredAddressType == "" {
-        return "auto"
-    }
-    return preferredAddressType
+	if preferredAddressType == "" {
+		return "auto"
+	}
+	return preferredAddressType
 }
 
 func (p *PodIdentityCredentialProvider) GetAWSConfig(ctx context.Context) (aws.Config, error) {
 	preference := parseAddressPreference(p.preferredAddressType)
-    if preference == "auto" || preference == "ipv4" {
-        config, err := p.getConfigWithEndpoint(ctx, podIdentityAgentEndpointIPv4)
-        if err != nil {
+	if preference == "auto" || preference == "ipv4" {
+		config, err := p.getConfigWithEndpoint(ctx, podIdentityAgentEndpointIPv4)
+		if err != nil {
 			klog.Warningf("IPv4 endpoint attempt failed: %v", err)
-        } else {
+		} else {
 			return config, nil
-		}        
-    }
+		}
+	}
 
-    if preference == "ipv6" || preference == "auto" {
-        config, err := p.getConfigWithEndpoint(ctx, podIdentityAgentEndpointIPv6)
+	if preference == "ipv6" || preference == "auto" {
+		config, err := p.getConfigWithEndpoint(ctx, podIdentityAgentEndpointIPv6)
 
 		if err != nil {
 			klog.Warningf("IPv4 endpoint attempt failed: %v", err)
-        } else {
+		} else {
 			return config, nil
 		}
-    }
+	}
 
-    return aws.Config{}, fmt.Errorf("invalid preferred address type: %s", p.preferredAddressType)
+	return aws.Config{}, fmt.Errorf("invalid preferred address type: %s", p.preferredAddressType)
 }
 
 func (p *PodIdentityCredentialProvider) getConfigWithEndpoint(ctx context.Context, endpoint string) (aws.Config, error) {
-    provider := endpointcreds.New(endpoint,
-        func(opts *endpointcreds.Options) {
-            opts.AuthorizationTokenProvider = p.fetcher
-            opts.HTTPClient = p.httpClient
-        },
-    )
-    return config.LoadDefaultConfig(ctx,
-        config.WithCredentialsProvider(provider),
-        config.WithRegion(p.region),
-    )
+	provider := endpointcreds.New(endpoint,
+		func(opts *endpointcreds.Options) {
+			opts.AuthorizationTokenProvider = p.fetcher
+			opts.HTTPClient = p.httpClient
+		},
+	)
+	return config.LoadDefaultConfig(ctx,
+		config.WithCredentialsProvider(provider),
+		config.WithRegion(p.region),
+	)
 }

--- a/credential_provider/pod_identity_credential_provider.go
+++ b/credential_provider/pod_identity_credential_provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -99,10 +100,16 @@ func NewPodIdentityCredentialProvider(
 }
 
 func parseAddressPreference(preferredAddressType string) string {
-	if preferredAddressType == "" {
+	switch strings.ToLower(preferredAddressType) {
+	case "", "auto":
 		return "auto"
+	case "ipv4":
+		return "ipv4"
+	case "ipv6":
+		return "ipv6"
+	default:
+		return "auto" // Default to auto for invalid preferences
 	}
-	return preferredAddressType
 }
 
 func (p *PodIdentityCredentialProvider) GetAWSConfig(ctx context.Context) (aws.Config, error) {

--- a/credential_provider/pod_identity_credential_provider.go
+++ b/credential_provider/pod_identity_credential_provider.go
@@ -133,7 +133,7 @@ func (p *PodIdentityCredentialProvider) GetAWSConfig(ctx context.Context) (aws.C
 		}
 	}
 
-	return aws.Config{}, fmt.Errorf("invalid preferred address type: %s", p.preferredAddressType)
+	return aws.Config{}, fmt.Errorf("failed to get AWS config %s", p.preferredAddressType)
 }
 
 func (p *PodIdentityCredentialProvider) getConfigWithEndpoint(ctx context.Context, endpoint string) (aws.Config, error) {

--- a/credential_provider/pod_identity_credential_provider.go
+++ b/credential_provider/pod_identity_credential_provider.go
@@ -3,9 +3,10 @@ package credential_provider
 import (
 	"context"
 	"fmt"
-	"k8s.io/klog/v2"
 	"net/http"
 	"time"
+
+	"k8s.io/klog/v2"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"

--- a/credential_provider/pod_identity_credential_provider_test.go
+++ b/credential_provider/pod_identity_credential_provider_test.go
@@ -17,63 +17,77 @@ const (
 )
 
 func setupMockPodIdentityAgent(t *testing.T, isIPv4, shouldFail bool) *httptest.Server {
-	t.Helper()
-	var listener net.Listener
-	if isIPv4 {
-		listener, _ = net.Listen("tcp", "127.0.0.1:0")
-	} else {
-		listener, _ = net.Listen("tcp", "[::1]:0")
-	}
-	srv := &httptest.Server{
-		Listener:    listener,
-		EnableHTTP2: true,
-		Config: &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if shouldFail {
-				w.WriteHeader(http.StatusInternalServerError)
-				return
-			}
+    t.Helper()
+    var listener net.Listener
+    var err error
+    if isIPv4 {
+        listener, err = net.Listen("tcp4", "127.0.0.1:0")
+    } else {
+        listener, err = net.Listen("tcp6", "[::1]:0")
+    }
+    if err != nil {
+        t.Fatalf("Failed to create listener: %v", err)
+    }
 
-			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprintf(w, `{
-			   "AccessKeyId": "TEST_ACCESS_KEY",
-			   "SecretAccessKey": "TEST_SECRET",
-			   "Token": "TEST_TOKEN"
-		   }`)
-		})},
-	}
-	srv.Start()
-	return srv
+    srv := &httptest.Server{
+        Listener:    listener,
+        EnableHTTP2: true,
+        Config: &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+            if shouldFail {
+                w.WriteHeader(http.StatusInternalServerError)
+                return
+            }
+
+            w.Header().Set("Content-Type", "application/json")
+            fmt.Fprintf(w, `{
+               "AccessKeyId": "TEST_ACCESS_KEY",
+               "SecretAccessKey": "TEST_SECRET",
+               "Token": "TEST_TOKEN"
+           }`)
+        })},
+    }
+    srv.Start()
+    return srv
 }
 
 func newPodIdentityCredentialWithMock(t *testing.T, isIPv4 bool, tstData podIdentityCredentialTest) (*PodIdentityCredentialProvider, chan<- struct{}) {
-	k8sClient := &mockK8sV1{
-		CoreV1Interface:  fake.NewSimpleClientset().CoreV1(),
-		fake:             fake.NewSimpleClientset().CoreV1(),
-		k8CTOneShotError: tstData.k8CTOneShotError,
-	}
+    k8sClient := &mockK8sV1{
+        CoreV1Interface:  fake.NewSimpleClientset().CoreV1(),
+        fake:             fake.NewSimpleClientset().CoreV1(),
+        k8CTOneShotError: tstData.k8CTOneShotError,
+    }
 
-	mockServer := setupMockPodIdentityAgent(t, isIPv4, tstData.podIdentityError)
-	respChan := make(chan struct{})
-	go func(srv *httptest.Server) {
-		<-respChan
-		srv.Close()
-	}(mockServer)
+    mockServer := setupMockPodIdentityAgent(t, isIPv4, tstData.podIdentityError)
+    respChan := make(chan struct{})
+    go func(srv *httptest.Server) {
+        <-respChan
+        srv.Close()
+    }(mockServer)
 
-	var credentialEndpoint string
-	if isIPv4 {
-		credentialEndpoint = mockServer.URL
-		podIdentityAgentEndpointIPv4 = mockServer.URL
-	} else {
-		credentialEndpoint = mockServer.URL
-		podIdentityAgentEndpointIPv6 = mockServer.URL
-	}
+    // For auto cases, set both endpoints
+    if tstData.preferredEndpoint == "auto" {
+        if isIPv4 {
+            podIdentityAgentEndpointIPv4 = mockServer.URL
+            podIdentityAgentEndpointIPv6 = "http://[::1]:1" // Invalid IPv6 endpoint
+        } else {
+            podIdentityAgentEndpointIPv4 = "http://127.0.0.1:1" // Invalid IPv4 endpoint
+            podIdentityAgentEndpointIPv6 = mockServer.URL
+        }
+    } else {
+        // For specific IPv4/IPv6 cases
+        if isIPv4 {
+            podIdentityAgentEndpointIPv4 = mockServer.URL
+        } else {
+            podIdentityAgentEndpointIPv6 = mockServer.URL
+        }
+    }
 
-	return &PodIdentityCredentialProvider{
-		region:             testRegion,
-		credentialEndpoint: credentialEndpoint,
-		fetcher:            newPodIdentityTokenFetcher(testNamespace, testServiceAccount, testPodName, k8sClient),
-		httpClient:         http.DefaultClient,
-	}, respChan
+    return &PodIdentityCredentialProvider{
+        region:               testRegion,
+        preferredAddressType: tstData.preferredEndpoint,
+        fetcher:             newPodIdentityTokenFetcher(testNamespace, testServiceAccount, testPodName, k8sClient),
+        httpClient:          http.DefaultClient,
+    }, respChan
 }
 
 type podIdentityCredentialTest struct {
@@ -86,37 +100,46 @@ type podIdentityCredentialTest struct {
 }
 
 var podIdentityCredentialTests []podIdentityCredentialTest = []podIdentityCredentialTest{
-	{"Pod Identity Success via IPv4", false, false, false, "ipv4", ""},
-	{"Pod Identity Success via IPv6", false, false, false, "ipv6", ""},
-	{"Pod Identity Success via auto selection", false, false, false, "auto", ""},
-	{"Pod identity Failure via IPv4", false, false, true, "ipv4", "failed to refresh cached credentials, failed to load credentials, exceeded maximum number of attempts, 3, : "},
-	{"Pod identity Failure via IPv6", false, false, true, "ipv6", "failed to refresh cached credentials, failed to load credentials, exceeded maximum number of attempts, 3, : "},
-	{"Pod identity Failure via auto selection", false, false, true, "auto", "failed to refresh cached credentials, failed to load credentials, exceeded maximum number of attempts, 3, : "},
+    {"Pod Identity Success via IPv4", false, false, false, "ipv4", ""},
+    {"Pod Identity Success via IPv6", false, false, false, "ipv6", ""},
+    {"Pod Identity Success via auto selection", false, false, false, "auto", ""},
+    {"Pod identity Failure via IPv4", false, false, true, "ipv4", "failed to refresh cached credentials"},
+    {"Pod identity Failure via IPv6", false, false, true, "ipv6", "failed to refresh cached credentials"},
+    {"Pod identity Failure via auto selection", false, false, true, "auto", "failed to refresh cached credentials"},
 }
 
 func TestPodIdentityCredentialProvider(t *testing.T) {
-	for _, tstData := range podIdentityCredentialTests {
-		t.Run(tstData.testName, func(t *testing.T) {
-			provider, closer := newPodIdentityCredentialWithMock(t, tstData.preferredEndpoint == "ipv4", tstData)
-			defer func() { closer <- struct{}{} }()
+    defer func() {
+        podIdentityAgentEndpointIPv4 = defaultIPv4Endpoint
+        podIdentityAgentEndpointIPv6 = defaultIPv6Endpoint
+    }()
 
-			cfg, _ := provider.GetAWSConfig(context.Background())
-			_, err := cfg.Credentials.Retrieve(context.Background())
+    for _, tstData := range podIdentityCredentialTests {
+        t.Run(tstData.testName, func(t *testing.T) {
+            isIPv4 := tstData.preferredEndpoint == "ipv4" || 
+                     (tstData.preferredEndpoint == "auto" && !tstData.podIdentityError)
+            
+            provider, closer := newPodIdentityCredentialWithMock(t, isIPv4, tstData)
+            defer func() { closer <- struct{}{} }()
 
-			if len(tstData.expError) == 0 && err != nil {
-				t.Errorf("%s case: got unexpected cred provider error: %s", tstData.testName, err)
-			}
-			if len(tstData.expError) == 0 && cfg.Credentials == nil {
-				t.Errorf("%s case: got empty credential provider", tstData.testName)
-			}
-			if len(tstData.expError) != 0 && err == nil {
-				t.Fatalf("%s case: expected error but got none", tstData.testName)
-			}
-			if len(tstData.expError) != 0 && !strings.Contains(err.Error(), tstData.expError) {
-				t.Errorf("%s case: expected error prefix '%s' but got '%s'", tstData.testName, tstData.expError, err.Error())
-			}
-		})
-	}
+            cfg, _ := provider.GetAWSConfig(context.Background())
+            _, err := cfg.Credentials.Retrieve(context.Background())
+
+            if len(tstData.expError) == 0 && err != nil {
+                t.Errorf("%s case: got unexpected cred provider error: %s", tstData.testName, err)
+            }
+            if len(tstData.expError) == 0 && cfg.Credentials == nil {
+                t.Errorf("%s case: got empty credential provider", tstData.testName)
+            }
+            if len(tstData.expError) != 0 && err == nil {
+                t.Fatalf("%s case: expected error but got none", tstData.testName)
+            }
+            if len(tstData.expError) != 0 && !strings.Contains(err.Error(), tstData.expError) {
+                t.Errorf("%s case: error message '%s' does not contain expected text '%s'", 
+                    tstData.testName, err.Error(), tstData.expError)
+            }
+        })
+    }
 }
 
 var podIdentityTokenTests = []podIdentityCredentialTest{

--- a/credential_provider/pod_identity_credential_provider_test.go
+++ b/credential_provider/pod_identity_credential_provider_test.go
@@ -17,77 +17,77 @@ const (
 )
 
 func setupMockPodIdentityAgent(t *testing.T, isIPv4, shouldFail bool) *httptest.Server {
-    t.Helper()
-    var listener net.Listener
-    var err error
-    if isIPv4 {
-        listener, err = net.Listen("tcp4", "127.0.0.1:0")
-    } else {
-        listener, err = net.Listen("tcp6", "[::1]:0")
-    }
-    if err != nil {
-        t.Fatalf("Failed to create listener: %v", err)
-    }
+	t.Helper()
+	var listener net.Listener
+	var err error
+	if isIPv4 {
+		listener, err = net.Listen("tcp4", "127.0.0.1:0")
+	} else {
+		listener, err = net.Listen("tcp6", "[::1]:0")
+	}
+	if err != nil {
+		t.Fatalf("Failed to create listener: %v", err)
+	}
 
-    srv := &httptest.Server{
-        Listener:    listener,
-        EnableHTTP2: true,
-        Config: &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-            if shouldFail {
-                w.WriteHeader(http.StatusInternalServerError)
-                return
-            }
+	srv := &httptest.Server{
+		Listener:    listener,
+		EnableHTTP2: true,
+		Config: &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if shouldFail {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
 
-            w.Header().Set("Content-Type", "application/json")
-            fmt.Fprintf(w, `{
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{
                "AccessKeyId": "TEST_ACCESS_KEY",
                "SecretAccessKey": "TEST_SECRET",
                "Token": "TEST_TOKEN"
            }`)
-        })},
-    }
-    srv.Start()
-    return srv
+		})},
+	}
+	srv.Start()
+	return srv
 }
 
 func newPodIdentityCredentialWithMock(t *testing.T, isIPv4 bool, tstData podIdentityCredentialTest) (*PodIdentityCredentialProvider, chan<- struct{}) {
-    k8sClient := &mockK8sV1{
-        CoreV1Interface:  fake.NewSimpleClientset().CoreV1(),
-        fake:             fake.NewSimpleClientset().CoreV1(),
-        k8CTOneShotError: tstData.k8CTOneShotError,
-    }
+	k8sClient := &mockK8sV1{
+		CoreV1Interface:  fake.NewSimpleClientset().CoreV1(),
+		fake:             fake.NewSimpleClientset().CoreV1(),
+		k8CTOneShotError: tstData.k8CTOneShotError,
+	}
 
-    mockServer := setupMockPodIdentityAgent(t, isIPv4, tstData.podIdentityError)
-    respChan := make(chan struct{})
-    go func(srv *httptest.Server) {
-        <-respChan
-        srv.Close()
-    }(mockServer)
+	mockServer := setupMockPodIdentityAgent(t, isIPv4, tstData.podIdentityError)
+	respChan := make(chan struct{})
+	go func(srv *httptest.Server) {
+		<-respChan
+		srv.Close()
+	}(mockServer)
 
-    // For auto cases, set both endpoints
-    if tstData.preferredEndpoint == "auto" {
-        if isIPv4 {
-            podIdentityAgentEndpointIPv4 = mockServer.URL
-            podIdentityAgentEndpointIPv6 = "http://[::1]:1" // Invalid IPv6 endpoint
-        } else {
-            podIdentityAgentEndpointIPv4 = "http://127.0.0.1:1" // Invalid IPv4 endpoint
-            podIdentityAgentEndpointIPv6 = mockServer.URL
-        }
-    } else {
-        // For specific IPv4/IPv6 cases
-        if isIPv4 {
-            podIdentityAgentEndpointIPv4 = mockServer.URL
-        } else {
-            podIdentityAgentEndpointIPv6 = mockServer.URL
-        }
-    }
+	// For auto cases, set both endpoints
+	if tstData.preferredEndpoint == "auto" {
+		if isIPv4 {
+			podIdentityAgentEndpointIPv4 = mockServer.URL
+			podIdentityAgentEndpointIPv6 = "http://[::1]:1" // Invalid IPv6 endpoint
+		} else {
+			podIdentityAgentEndpointIPv4 = "http://127.0.0.1:1" // Invalid IPv4 endpoint
+			podIdentityAgentEndpointIPv6 = mockServer.URL
+		}
+	} else {
+		// For specific IPv4/IPv6 cases
+		if isIPv4 {
+			podIdentityAgentEndpointIPv4 = mockServer.URL
+		} else {
+			podIdentityAgentEndpointIPv6 = mockServer.URL
+		}
+	}
 
-    return &PodIdentityCredentialProvider{
-        region:               testRegion,
-        preferredAddressType: tstData.preferredEndpoint,
-        fetcher:             newPodIdentityTokenFetcher(testNamespace, testServiceAccount, testPodName, k8sClient),
-        httpClient:          http.DefaultClient,
-    }, respChan
+	return &PodIdentityCredentialProvider{
+		region:               testRegion,
+		preferredAddressType: tstData.preferredEndpoint,
+		fetcher:              newPodIdentityTokenFetcher(testNamespace, testServiceAccount, testPodName, k8sClient),
+		httpClient:           http.DefaultClient,
+	}, respChan
 }
 
 type podIdentityCredentialTest struct {
@@ -100,46 +100,46 @@ type podIdentityCredentialTest struct {
 }
 
 var podIdentityCredentialTests []podIdentityCredentialTest = []podIdentityCredentialTest{
-    {"Pod Identity Success via IPv4", false, false, false, "ipv4", ""},
-    {"Pod Identity Success via IPv6", false, false, false, "ipv6", ""},
-    {"Pod Identity Success via auto selection", false, false, false, "auto", ""},
-    {"Pod identity Failure via IPv4", false, false, true, "ipv4", "failed to refresh cached credentials"},
-    {"Pod identity Failure via IPv6", false, false, true, "ipv6", "failed to refresh cached credentials"},
-    {"Pod identity Failure via auto selection", false, false, true, "auto", "failed to refresh cached credentials"},
+	{"Pod Identity Success via IPv4", false, false, false, "ipv4", ""},
+	{"Pod Identity Success via IPv6", false, false, false, "ipv6", ""},
+	{"Pod Identity Success via auto selection", false, false, false, "auto", ""},
+	{"Pod identity Failure via IPv4", false, false, true, "ipv4", "failed to refresh cached credentials"},
+	{"Pod identity Failure via IPv6", false, false, true, "ipv6", "failed to refresh cached credentials"},
+	{"Pod identity Failure via auto selection", false, false, true, "auto", "failed to refresh cached credentials"},
 }
 
 func TestPodIdentityCredentialProvider(t *testing.T) {
-    defer func() {
-        podIdentityAgentEndpointIPv4 = defaultIPv4Endpoint
-        podIdentityAgentEndpointIPv6 = defaultIPv6Endpoint
-    }()
+	defer func() {
+		podIdentityAgentEndpointIPv4 = defaultIPv4Endpoint
+		podIdentityAgentEndpointIPv6 = defaultIPv6Endpoint
+	}()
 
-    for _, tstData := range podIdentityCredentialTests {
-        t.Run(tstData.testName, func(t *testing.T) {
-            isIPv4 := tstData.preferredEndpoint == "ipv4" || 
-                     (tstData.preferredEndpoint == "auto" && !tstData.podIdentityError)
-            
-            provider, closer := newPodIdentityCredentialWithMock(t, isIPv4, tstData)
-            defer func() { closer <- struct{}{} }()
+	for _, tstData := range podIdentityCredentialTests {
+		t.Run(tstData.testName, func(t *testing.T) {
+			isIPv4 := tstData.preferredEndpoint == "ipv4" ||
+				(tstData.preferredEndpoint == "auto" && !tstData.podIdentityError)
 
-            cfg, _ := provider.GetAWSConfig(context.Background())
-            _, err := cfg.Credentials.Retrieve(context.Background())
+			provider, closer := newPodIdentityCredentialWithMock(t, isIPv4, tstData)
+			defer func() { closer <- struct{}{} }()
 
-            if len(tstData.expError) == 0 && err != nil {
-                t.Errorf("%s case: got unexpected cred provider error: %s", tstData.testName, err)
-            }
-            if len(tstData.expError) == 0 && cfg.Credentials == nil {
-                t.Errorf("%s case: got empty credential provider", tstData.testName)
-            }
-            if len(tstData.expError) != 0 && err == nil {
-                t.Fatalf("%s case: expected error but got none", tstData.testName)
-            }
-            if len(tstData.expError) != 0 && !strings.Contains(err.Error(), tstData.expError) {
-                t.Errorf("%s case: error message '%s' does not contain expected text '%s'", 
-                    tstData.testName, err.Error(), tstData.expError)
-            }
-        })
-    }
+			cfg, _ := provider.GetAWSConfig(context.Background())
+			_, err := cfg.Credentials.Retrieve(context.Background())
+
+			if len(tstData.expError) == 0 && err != nil {
+				t.Errorf("%s case: got unexpected cred provider error: %s", tstData.testName, err)
+			}
+			if len(tstData.expError) == 0 && cfg.Credentials == nil {
+				t.Errorf("%s case: got empty credential provider", tstData.testName)
+			}
+			if len(tstData.expError) != 0 && err == nil {
+				t.Fatalf("%s case: expected error but got none", tstData.testName)
+			}
+			if len(tstData.expError) != 0 && !strings.Contains(err.Error(), tstData.expError) {
+				t.Errorf("%s case: error message '%s' does not contain expected text '%s'",
+					tstData.testName, err.Error(), tstData.expError)
+			}
+		})
+	}
 }
 
 var podIdentityTokenTests = []podIdentityCredentialTest{


### PR DESCRIPTION
*Description of changes:*
- Added parseAddressPreference helper to normalize empty input to "auto"
- Refactored GetAWSConfig method to use the new helper
- Implemented IPv4 to IPv6 fallback for "auto" preference
- Maintained explicit IPv4 and IPv6 options

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
