### PR TITLE
Build the Docker image without QEMU, load Docker image for future use.

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -4,25 +4,34 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    types: [opened, synchronize, ready_for_review]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
+        include:
+        - os: linux
+        - arch: amd64
+          runner: ubuntu-latest
+        - arch: arm64
+          runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
 
       - name: Build the Docker image
         uses: docker/build-push-action@v6
         with:
           build-args: LDFLAGS=-X 'github.com/aws/secrets-store-csi-driver-provider-aws/server.Version=fakeversion' -X 'github.com/aws/secrets-store-csi-driver-provider-aws/auth.ProviderVersion=fakeversion' -extldflags '-static'
           context: .
-          platforms: linux/amd64,linux/arm64
-          push: false
-          tags: test-build:latest
+          platforms: ${{ matrix.os }}/${{ matrix.arch }}
+          load: true
+          tags: test-build:latest-${{ matrix.arch }}
+
+      - name: List images
+        run: |
+          docker image ls -a


### PR DESCRIPTION
Issue #, if available:*

*Description of changes:*
We currently build the Docker image in GH actions using QEMU. This is really slow, especially for the ARM64 build. ARM public GH runners are in public beta.

Update the Docker GitHub action to build separately for ARM64 and x86. Load the Docker image for future use (integration tests).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
