### PR TITLE
Add note about grpcSupportedProviders flag for older driver versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ AWS offers two services to manage secrets and parameters conveniently in your co
     helm repo add secrets-store-csi-driver https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts
     helm install -n kube-system csi-secrets-store secrets-store-csi-driver/secrets-store-csi-driver
     ```
-  **Note** that older versions of the driver may require the ```--set grpcSupportedProviders="aws"``` flag on the install step.
+  **Note** that older versions of the driver may require the ```--set grpcSupportedProviders="aws"``` flag on the install step.  
+  **Note** this step can be skipped if installing from Helm. The Helm chart for the ASCP by default automatically installs a compatible version of the Secrets Store CSI driver as a helm dependency. This can be disabled by setting `secrets-store-csi-driver.install=false`.
 * IAM Roles for Service Accounts ([IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)) or [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) as described in the usage section below.
 
 [^1]: The CSI Secret Store driver runs as a DaemonSet, and as described in the [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/fargate.html#fargate-considerations), DaemonSet is not supported on Fargate.


### PR DESCRIPTION
*Description of changes:*

Add documentation note that older versions of the Secrets Store CSI driver may require 
the `--set grpcSupportedProviders="aws"` flag during installation. 
Also clarify that this step can be skipped when installing via Helm, as the chart automatically installs 
a compatible CSI driver version by default, which can be disabled with 
`secrets-store-csi-driver.install=false.`

PR: https://github.com/aws/secrets-store-csi-driver-provider-aws/pull/384

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
