### PR TITLE
Remove unreachable error, fix gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,4 @@ _output
 # JetBrains
 .idea/
 
-./secrets-store-csi-driver-provider-aws
+secrets-store-csi-driver-provider-aws

--- a/server/server.go
+++ b/server/server.go
@@ -152,10 +152,6 @@ func (s *CSIDriverProviderServer) Mount(ctx context.Context, req *v1alpha1.Mount
 	if err != nil {
 		return nil, err
 	}
-	if len(awsConfigs) > 2 {
-		klog.Errorf("Max number of region(s) exceeded: %s", strings.Join(regions, ", "))
-		return nil, err
-	}
 
 	// Get the list of secrets to mount. These will be grouped together by type
 	// in a map of slices (map[string][]*SecretDescriptor) keyed by secret type


### PR DESCRIPTION
- **Remove unreachable error**
- **Fix gitignore**

*Issue #, if available:*

*Description of changes:*
This error is not reachable (there is no way to write a test for it). Remove it.

Fixed gitignore, it was not excluding the built binary from `go build` correctly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
