### PR TITLE
Remove http timeout for pod identity credential provider

### DIFF
--- a/credential_provider/pod_identity_credential_provider.go
+++ b/credential_provider/pod_identity_credential_provider.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
 	"k8s.io/klog/v2"
 
@@ -22,7 +21,6 @@ const (
 	podIdentityAudience = "pods.eks.amazonaws.com"
 	defaultIPv4Endpoint = "http://169.254.170.23/v1/credentials"
 	defaultIPv6Endpoint = "http://[fd00:ec2::23]/v1/credentials"
-	httpTimeout         = 100 * time.Millisecond
 )
 
 var (
@@ -93,9 +91,7 @@ func NewPodIdentityCredentialProvider(
 		region:               region,
 		preferredAddressType: preferredAddressType,
 		fetcher:              newPodIdentityTokenFetcher(nameSpace, svcAcc, podName, k8sClient),
-		httpClient: &http.Client{
-			Timeout: httpTimeout,
-		},
+		httpClient:           &http.Client{},
 	}, nil
 }
 


### PR DESCRIPTION
*Issue #, if available:*
When configuring secrets store csi driver provider for aws with pod identity for EKS Hybrid, it shows the following error message in test pod.

```
  Warning  FailedMount  97s (x14 over 15m)  kubelet            MountVolume.SetUp failed for volume "secrets-store-inline" : rpc error: code = Unknown desc = failed to mount secrets store objects for pod default/nginx-pod-identity-deployment-98dbb5969-jkjtn, err: rpc error: code = Unknown desc = Failed to fetch secret from all regions. Verify secret exists and required permissions are granted for: MySecret
```

Looking at pod identity logs, it shows the request was cancelled.

```
{"client-addr":"10.86.56.9:46226","cluster-name":"eks-hybrid-cilium","level":"info","msg":"Calling EKS Auth to fetch credentials","time":"2025-08-21T01:46:45Z"}
{"client-addr":"10.86.56.9:46226","cluster-name":"eks-hybrid-cilium","level":"error","msg":"Error fetching credentials: error getting credentials to cache: unable to fetch credentials from EKS Auth: operation error EKS Auth: AssumeRoleForPodIdentity, https response error StatusCode: 0, RequestID: , canceled, context canceled","operation":"AssumeRoleForPodIdentity","request-id":"","service":"EKS Auth","time":"2025-08-21T01:46:45Z"}
{"client-addr":"10.86.56.9:46232","cluster-name":"eks-hybrid-cilium","level":"info","msg":"handling new request request from 10.86.56.9:46232","time":"2025-08-21T01:46:47Z"}
```

The issue was caused by setting 100 milliseconds timeout in http client when construct pod identity credential provider. For EKS hybrid scenario, worker nodes are on prem nodes and controlled by customer, which may not be close enough from aws region. Thus it can take longer to receive response when pod identity credential provider make the remote call.

*Description of changes:*
For now, remove timeout from http client.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
