### PR TITLE
Override the name of the SSCD to the correct value

### DIFF
--- a/charts/secrets-store-csi-driver-provider-aws/values.yaml
+++ b/charts/secrets-store-csi-driver-provider-aws/values.yaml
@@ -51,3 +51,4 @@ dnsConfig: {}
 
 secrets-store-csi-driver:
   install: true
+  fullnameOverride: secrets-store-csi-driver


### PR DESCRIPTION
*Issue #, if available:*
Closes #496

Accidentally closed #498 on a force push.

*Description of changes:*

When performing a Helm installation with the name `secrets-store-csi-driver-provider-aws`, the name will be passed to both the driver and provider daemonsets. This will cause the provider daemonset to fail to install since the driver will already have the name.

Override the name of the SSCD dependency chart to always be `secrets-store-csi-driver`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
