### PR TITLE
fix: use OIDC for Codecov

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   build:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -63,5 +63,6 @@ jobs:
 
       - name: Codecov
         uses: codecov/codecov-action@v5
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          fail_ci_if_error: true
+          use_oidc: true


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Code coverage broke due to GitHub separating repository secrets from Dependabot secrets. Use the OIDC token to write code coverage data to Codecov.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
