### PR TITLE
Increase the role assumption duration

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -126,6 +126,7 @@ jobs:
           role-to-assume: ${{ secrets.ROLE_ARN }}
           role-session-name: csi-driver-ci-${{ github.run_id }}-${{ matrix.arch }}
           aws-region: us-west-2
+          role-duration-seconds: 14400
 
       - name: Run integ tests
         run: cd tests && ./run-tests.sh ${{ matrix.arch-short }}-${{ matrix.auth_type }}


### PR DESCRIPTION
Tests occasionally time out due to the runs taking a little over one hour. Increase the role assumption duration to 4 hours.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
