### PR TITLE
chore: fetch nginx from ECR Public Gallery

### DIFF
--- a/charts/secrets-store-csi-driver-provider-aws/values.yaml
+++ b/charts/secrets-store-csi-driver-provider-aws/values.yaml
@@ -23,7 +23,7 @@ affinity:
             - key: "eks.amazonaws.com/compute-type"
               operator: NotIn
               values:
-              - fargate
+                - fargate
 
 resources:
   requests:

--- a/deployment/private-installer.yaml
+++ b/deployment/private-installer.yaml
@@ -10,18 +10,18 @@ kind: ClusterRole
 metadata:
   name: csi-secrets-store-provider-aws-cluster-role
 rules:
-- apiGroups: [""]
-  resources: ["serviceaccounts/token"]
-  verbs: ["create"]
-- apiGroups: [""]
-  resources: ["serviceaccounts"]
-  verbs: ["get"]
-- apiGroups: [""]
-  resources: ["pods"]
-  verbs: ["get"]
-- apiGroups: [""]
-  resources: ["nodes"]
-  verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts/token"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -32,9 +32,9 @@ roleRef:
   kind: ClusterRole
   name: csi-secrets-store-provider-aws-cluster-role
 subjects:
-- kind: ServiceAccount
-  name: csi-secrets-store-provider-aws
-  namespace: kube-system
+  - kind: ServiceAccount
+    name: csi-secrets-store-provider-aws
+    namespace: kube-system
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -61,8 +61,8 @@ spec:
           image: ${PRIVREPO}
           imagePullPolicy: Always
           args:
-              - --provider-volume=/var/run/secrets-store-csi-providers
-              - --driver-writes-secrets=false
+            - --provider-volume=/var/run/secrets-store-csi-providers
+            - --driver-writes-secrets=false
           resources:
             requests:
               cpu: 50m

--- a/examples/ExampleDeployment-IRSA.yaml
+++ b/examples/ExampleDeployment-IRSA.yaml
@@ -30,19 +30,18 @@ spec:
     spec:
       serviceAccountName: nginx-irsa-deployment-sa
       volumes:
-      - name: secrets-store-inline
-        csi:
-          driver: secrets-store.csi.k8s.io
-          readOnly: true
-          volumeAttributes:
-            secretProviderClass: "nginx-irsa-deployment-aws-secrets"
-      containers:
-      - name: nginx-irsa-deployment
-        image: nginx
-        ports:
-        - containerPort: 80
-        volumeMounts:
         - name: secrets-store-inline
-          mountPath: "/mnt/secrets-store"
-          readOnly: true
-
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: "nginx-irsa-deployment-aws-secrets"
+      containers:
+        - name: nginx-irsa-deployment
+          image: public.ecr.aws/nginx/nginx:latest
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: secrets-store-inline
+              mountPath: "/mnt/secrets-store"
+              readOnly: true

--- a/examples/ExampleDeployment-PodIdentity.yaml
+++ b/examples/ExampleDeployment-PodIdentity.yaml
@@ -38,7 +38,7 @@ spec:
               secretProviderClass: "nginx-pod-identity-deployment-aws-secrets"
       containers:
         - name: nginx-pod-identity-deployment
-          image: nginx
+          image: public.ecr.aws/nginx/nginx:latest
           ports:
             - containerPort: 80
           volumeMounts:

--- a/examples/ExampleSecretProviderClass-IRSA.yaml
+++ b/examples/ExampleSecretProviderClass-IRSA.yaml
@@ -6,5 +6,5 @@ spec:
   provider: aws
   parameters:
     objects: |
-        - objectName: "MySecret"
-          objectType: "secretsmanager"
+      - objectName: "MySecret"
+        objectType: "secretsmanager"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
- The nginx image currently defined in the example deployment files isn't accessible from clusters in AWS China regions. Fetch nginx from the ECR Public Gallery to fix this.
- Format yaml files

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
