### PR TITLE
Add id-token write permission to release chart

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -3,6 +3,9 @@ name: "Release Helm Chart"
 on:
   workflow_dispatch:
 
+permissions:
+  id-token: write
+
 jobs:
   test:
     uses: ./.github/workflows/go.yml


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add id-token write permission to release chart

Failing Helm chart release workflow: https://github.com/aws/secrets-store-csi-driver-provider-aws/actions/runs/21645181865

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
