### PR TITLE
Add contents read permission for release chart

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: read
   id-token: write
 
 jobs:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add contents read permission for release chart

The release chart workflow failed: https://github.com/aws/secrets-store-csi-driver-provider-aws/actions/runs/21648520700

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
