### PR TITLE
feat(tests): add EKS add-on testing support

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,6 @@
 ## Running integration tests
 
-1. Build and push a provider image (see [Private Builds](https://github.com/aws/secrets-store-csi-driver-provider-aws/tree/main#private-builds) in the main README).
+1. Build and push a provider image (see [Private Builds](https://github.com/aws/secrets-store-csi-driver-provider-aws/tree/main#private-builds) in the main README). Not required if using `--addon`.
 2. `cd` into the `tests/` directory.
 3. Run the setup script:
 
@@ -25,7 +25,7 @@ You can also run individual setup steps: `./setup.sh deps`, `./setup.sh venv`, o
    source .venv/bin/activate.fish     # fish
    ```
    `run-tests.sh` will auto-activate the bash venv as a fallback if boto3 isn't already importable.
-6. Ensure that the `PRIVREPO` environment variable is set.
+6. Ensure that the `PRIVREPO` environment variable is set (not required if using `--addon` flag).
 7. Run `./run-tests.sh`
 
 ### Test targets
@@ -41,6 +41,18 @@ You can also run individual setup steps: `./setup.sh deps`, `./setup.sh venv`, o
 | `./run-tests.sh x64-pod-identity` | Single test                         |
 | `./run-tests.sh arm-irsa`         | Single test                         |
 | `./run-tests.sh arm-pod-identity` | Single test                         |
+
+### Flags
+
+- `--addon` — Install via EKS add-on instead of Helm (skips `PRIVREPO` requirement)
+- `--version <ver>` — Specify EKS add-on version (requires `--addon`)
+
+Examples:
+
+```bash
+./run-tests.sh --addon
+./run-tests.sh x64-irsa --addon --version v2.1.1-eksbuild.1
+```
 
 ### Cleanup
 
@@ -66,7 +78,7 @@ If any test fails, diagnostics (pod status, describe, logs, events) are captured
 
 | Variable                | Required                     | Description                                                          |
 | ----------------------- | ---------------------------- | -------------------------------------------------------------------- |
-| `PRIVREPO`              | Yes                          | Container image URI for the provider                                 |
+| `PRIVREPO`              | Yes (unless `--addon`)       | Container image URI for the provider                                 |
 | `PRIVTAG`               | No                           | Image tag (appended to PRIVREPO with `:` separator)                  |
 | `POD_IDENTITY_ROLE_ARN` | Yes (for pod-identity tests) | IAM role ARN for Pod Identity                                        |
 | `REGION`                | No                           | Primary AWS region (auto-detected)                                   |

--- a/tests/addon_config_values.yaml
+++ b/tests/addon_config_values.yaml
@@ -1,0 +1,35 @@
+# Comprehensive addon config exercising every schema property.
+# This catches schema typos that would cause 500s on create-addon.
+podLabels:
+  integ-test: "true"
+podAnnotations:
+  integ-test-annotation: "true"
+tolerations:
+  - operator: Exists
+resources:
+  requests:
+    cpu: 50m
+    memory: 100Mi
+  limits:
+    cpu: 50m
+    memory: 100Mi
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: eks.amazonaws.com/compute-type
+              operator: NotIn
+              values:
+                - fargate
+nodeSelector: {}
+dnsConfig: {}
+port: 8989
+driverWritesSecrets: false
+useFipsEndpoint: false
+priorityClassName: ""
+secrets-store-csi-driver:
+  enableSecretRotation: true
+  rotationPollInterval: 15s
+  syncSecret:
+    enabled: true

--- a/tests/integration.bats
+++ b/tests/integration.bats
@@ -4,7 +4,7 @@
 # Driven entirely by environment variables — no template generation needed.
 #
 # Required env vars: ARCH, AUTH_TYPE, REGION, FAILOVERREGION
-# Optional: PRIVREPO, PRIVTAG, POD_IDENTITY_ROLE_ARN
+# Optional: USE_ADDON, ADDON_VERSION, PRIVREPO, PRIVTAG, POD_IDENTITY_ROLE_ARN
 
 load helpers
 
@@ -74,12 +74,22 @@ setup_auth() {
 }
 
 install_driver() {
-	log "Installing secrets-store-csi-driver via Helm"
-	helm repo add secrets-store-csi-driver https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts
-	KUBECONFIG="$KUBECONFIG_FILE" helm --namespace="$NAMESPACE" install csi-secrets-store \
-		secrets-store-csi-driver/secrets-store-csi-driver \
-		--set enableSecretRotation=true --set rotationPollInterval=15s --set syncSecret.enabled=true \
-		--timeout "$WAIT_LONG" --wait
+	if [[ "$USE_ADDON" == "true" ]]; then
+		local version_flag=""
+		[[ -n "$ADDON_VERSION" ]] && version_flag="--addon-version $ADDON_VERSION"
+		log "Installing via EKS addon"
+		aws eks create-addon --cluster-name "$CLUSTER_NAME" --addon-name aws-secrets-store-csi-driver-provider \
+			--configuration-values "file://addon_config_values.yaml" $version_flag --region "$REGION" >&3 2>&1
+		aws eks wait addon-active --cluster-name "$CLUSTER_NAME" --addon-name aws-secrets-store-csi-driver-provider \
+			--region "$REGION" >&3 2>&1
+	else
+		log "Installing secrets-store-csi-driver via Helm"
+		helm repo add secrets-store-csi-driver https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts
+		KUBECONFIG="$KUBECONFIG_FILE" helm --namespace="$NAMESPACE" install csi-secrets-store \
+			secrets-store-csi-driver/secrets-store-csi-driver \
+			--set enableSecretRotation=true --set rotationPollInterval=15s --set syncSecret.enabled=true \
+			--timeout "$WAIT_LONG" --wait
+	fi
 }
 
 # --- bats lifecycle ---
@@ -151,7 +161,40 @@ validate_jmes_mount() {
 
 # --- Tests ---
 
+@test "addon config schema options applied" {
+	[[ "$USE_ADDON" != "true" ]] && skip "Only applies to addon installs"
+	log "Verifying addon config schema options"
+
+	local addon_ns="aws-secrets-manager"
+	local ds="daemonset/aws-secrets-store-csi-driver-provider"
+	dskctl() { kubectl --kubeconfig="$KUBECONFIG_FILE" --namespace "$addon_ns" "$@"; }
+
+	# podLabels
+	result=$(dskctl get "$ds" -o jsonpath='{.spec.template.metadata.labels.integ-test}')
+	[[ "$result" == "true" ]]
+
+	# podAnnotations
+	result=$(dskctl get "$ds" -o jsonpath='{.spec.template.metadata.annotations.integ-test-annotation}')
+	[[ "$result" == "true" ]]
+
+	# resources
+	result=$(dskctl get "$ds" -o jsonpath='{.spec.template.spec.containers[0].resources.requests.cpu}')
+	[[ "$result" == "50m" ]]
+
+	result=$(dskctl get "$ds" -o jsonpath='{.spec.template.spec.containers[0].resources.requests.memory}')
+	[[ "$result" == "100Mi" ]]
+
+	# tolerations
+	result=$(dskctl get "$ds" -o jsonpath='{.spec.template.spec.tolerations[?(@.operator=="Exists")].operator}')
+	[[ "$result" == "Exists" ]]
+
+	# port (appears as a container arg)
+	run dskctl get "$ds" -o jsonpath='{.spec.template.spec.containers[0].args}'
+	assert_success
+}
+
 @test "Install aws provider" {
+	[[ "$USE_ADDON" == "true" ]] && skip "Provider installed via addon"
 	log "Installing AWS provider"
 
 	local image="${PRIVREPO}${PRIVTAG:+:${PRIVTAG}}"

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 # --- Configuration ---
 
+USE_ADDON=false
+ADDON_VERSION=""
 PIDS=()
 LOG_DIR=""
 
@@ -66,9 +68,12 @@ target_needs_pod_identity() {
 
 check_tools() {
 	local missing=()
-	for tool in aws eksctl kubectl bats helm envsubst; do
+	for tool in aws eksctl kubectl bats envsubst; do
 		command -v "$tool" >/dev/null 2>&1 || missing+=("$tool")
 	done
+	if [[ "$USE_ADDON" != "true" ]]; then
+		command -v helm >/dev/null 2>&1 || missing+=("helm")
+	fi
 	if [[ ${#missing[@]} -gt 0 ]]; then
 		echo "Error: Missing required tools: ${missing[*]}"
 		exit 1
@@ -194,6 +199,7 @@ run_test() {
 	if [[ "$parallel" == "true" ]]; then
 		ARCH="$arch" AUTH_TYPE="$auth_type" \
 			REGION="$REGION" FAILOVERREGION="$FAILOVERREGION" \
+			USE_ADDON="$USE_ADDON" ADDON_VERSION="$ADDON_VERSION" \
 			POD_IDENTITY_ROLE_ARN="${POD_IDENTITY_ROLE_ARN:-}" \
 			PRIVREPO="${PRIVREPO:-}" PRIVTAG="${PRIVTAG:-}" \
 			bats integration.bats >"$log_file" 2>&1
@@ -207,6 +213,7 @@ run_test() {
 	else
 		ARCH="$arch" AUTH_TYPE="$auth_type" \
 			REGION="$REGION" FAILOVERREGION="$FAILOVERREGION" \
+			USE_ADDON="$USE_ADDON" ADDON_VERSION="$ADDON_VERSION" \
 			POD_IDENTITY_ROLE_ARN="${POD_IDENTITY_ROLE_ARN:-}" \
 			PRIVREPO="${PRIVREPO:-}" PRIVTAG="${PRIVTAG:-}" \
 			bats integration.bats 2>&1 | tee "$log_file"
@@ -226,7 +233,7 @@ run_parallel() {
 }
 
 validate_image() {
-	if [[ -z "${PRIVREPO:-}" ]]; then
+	if [[ "$USE_ADDON" == "true" ]] || [[ -z "${PRIVREPO:-}" ]]; then
 		return
 	fi
 	if [[ "$PRIVREPO" == *".dkr.ecr."*".amazonaws.com/"* ]]; then
@@ -266,10 +273,15 @@ elif [[ $# -gt 0 ]] && [[ "$1" != "--"* ]]; then
 	shift
 fi
 
-if [[ $# -gt 0 ]]; then
-	echo "Error: Unknown argument '$1'"
-	exit 1
-fi
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--addon)   USE_ADDON=true; shift ;;
+		--version) ADDON_VERSION="$2"; shift 2 ;;
+		*)         echo "Error: Unknown argument '$1'"; exit 1 ;;
+	esac
+done
+
+[[ -n "$ADDON_VERSION" ]] && [[ "$USE_ADDON" != "true" ]] && { echo "Error: --version requires --addon"; exit 1; }
 
 # --- Validation (skip for clean) ---
 
@@ -281,7 +293,7 @@ if [[ "$TEST_TARGET" != "clean" ]]; then
 		fi
 	fi
 
-	if [[ -z "${PRIVREPO:-}" ]]; then
+	if [[ "$USE_ADDON" != "true" ]] && [[ -z "${PRIVREPO:-}" ]]; then
 		echo "Error: PRIVREPO environment variable is not set"
 		exit 1
 	fi


### PR DESCRIPTION
**Issue #, if available:**

N/A

**Description of changes:**

Add support for testing the ASCP via EKS add-on installation, in addition to the existing Helm-based installation path.

**Changes:**

- **`tests/addon_config_values.yaml`** (new) — comprehensive add-on configuration fixture that exercises every property in the add-on config schema (podLabels, podAnnotations, tolerations, resources, affinity, nodeSelector, dnsConfig, port, driverWriteSecrets, useFipsEndpoint, priorityClassName, and CSI driver sub-chart settings). This catches schema typos that would cause 500 errors on `create-addon`.

- **`tests/integration.bats`** — added `install_driver()` add-on branch that installs via `aws eks create-addon` with the config values file. Added `addon config schema options applied` test case that verifies all config properties are correctly applied to the DaemonSet. Added skip condition on the `Install aws provider` test when running in add-on mode.

- **`tests/run-tests.sh`** — added `--addon` flag for add-on installation mode and `--version` flag for specifying the add-on version. Made `helm` tool check conditional (not required in add-on mode). Made `PRIVREPO` validation conditional (not required in add-on mode). Passes `USE_ADDON` and `ADDON_VERSION` through to bats.

- **`tests/README.md`** — documented the new flags with examples.

**Usage:**
```bash
./run-tests.sh --addon                                        # all 4 configs via add-on
./run-tests.sh x64-irsa --addon --version v2.1.1-eksbuild.1   # specific config + version
```

PR chain: #569 → #570 → **this PR** → #572

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.