### PR TITLE
feat(helm): add serviceAccount.annotations support

### DIFF
--- a/charts/secrets-store-csi-driver-provider-aws/templates/rbac.yaml
+++ b/charts/secrets-store-csi-driver-provider-aws/templates/rbac.yaml
@@ -43,4 +43,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "provider.labels" . | indent 4 }}
+{{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/secrets-store-csi-driver-provider-aws/values.yaml
+++ b/charts/secrets-store-csi-driver-provider-aws/values.yaml
@@ -48,6 +48,13 @@ imagePullSecrets: []
 rbac:
   install: true
 
+serviceAccount:
+  # Annotations to add to the service account
+  # Example for IRSA:
+  #   annotations:
+  #     eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/my-role
+  annotations: {}
+
 securityContext:
   privileged: false
   allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary

Add the ability to configure annotations on the ServiceAccount created by the Helm chart. This is essential for IRSA (IAM Roles for Service Accounts) where users need to set the `eks.amazonaws.com/role-arn` annotation.

## Problem

The Helm chart (version 2.1.x+) does not support setting annotations on the ServiceAccount it creates. This was reported in #549 and a feature request was opened in #550.

Without this capability, users cannot use IRSA with the provider when installing via Helm. They must either:
- Create the ServiceAccount separately with proper annotations
- Use `rbac.install: false` and manage all RBAC resources externally

## Solution

Add a `serviceAccount.annotations` configuration option to the Helm chart:

```yaml
serviceAccount:
  # Annotations to add to the service account
  # Example for IRSA:
  #   annotations:
  #     eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/my-role
  annotations: {}
```

## Changes

1. **values.yaml**: Added `serviceAccount.annotations` field with IRSA example in comments
2. **templates/rbac.yaml**: Added conditional annotations block to the ServiceAccount

## Test Plan

Verified the Helm template renders correctly:

**With annotations:**
```bash
helm template test . --set 'serviceAccount.annotations.eks\.amazonaws\.com/role-arn=arn:aws:iam::123456789012:role/my-role'
```

Output shows the ServiceAccount with the annotation:
```yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: test-secrets-store-csi-driver-provider-aws
  namespace: default
  labels:
    ...
  annotations:
    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/my-role
```

**Without annotations (default):**
```bash
helm template test .
```

Output shows the ServiceAccount without an annotations block (clean YAML).

## Breaking Changes

None. The default behavior is unchanged - annotations are only rendered when explicitly configured.

Fixes #549, #550