### PR TITLE
chore: add unified test infrastructure files [1/4]

### DIFF
--- a/tests/addon_config_values.yaml
+++ b/tests/addon_config_values.yaml
@@ -1,0 +1,50 @@
+# EKS addon configuration values for integration tests.
+#
+# This file exercises every schema property supported by the ASCP addon.
+# It serves two purposes:
+#   1. Verify that the addon installs correctly with all options set
+#   2. Catch schema typos that would cause 500 errors on create-addon
+#
+# The "addon config schema options applied" test in integration.bats validates
+# that these values are reflected in the deployed DaemonSet.
+
+podLabels:
+  integ-test: "true"
+podAnnotations:
+  integ-test-annotation: "true"
+tolerations:
+  - operator: Exists
+resources:
+  requests:
+    cpu: 50m
+    memory: 100Mi
+  limits:
+    cpu: 50m
+    memory: 100Mi
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: eks.amazonaws.com/compute-type
+              operator: NotIn
+              values:
+                - fargate
+nodeSelector: {}
+dnsConfig: {}
+port: 8989
+driverWritesSecrets: false
+useFipsEndpoint: false
+priorityClassName: ""
+
+# CSI driver sub-chart configuration.
+# enableSecretRotation + short poll interval are needed for rotation tests.
+# syncSecret is needed for the K8s Secret sync test.
+secrets-store-csi-driver:
+  enableSecretRotation: true
+  rotationPollInterval: 15s
+  syncSecret:
+    enabled: true
+  tokenRequests:
+    - audience: "sts.amazonaws.com"
+    - audience: "pods.eks.amazonaws.com"

--- a/tests/cfn/cluster-stack.yaml
+++ b/tests/cfn/cluster-stack.yaml
@@ -1,0 +1,416 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >-
+  EKS Auto Mode cluster infrastructure for integration tests.
+  Creates VPC, EKS cluster with Auto Mode, and auth configuration
+  (IRSA or Pod Identity). Test secrets/parameters are in test-resources.yaml.
+
+Parameters:
+  ClusterName:
+    Type: String
+  Suffix:
+    Type: String
+    Description: "e.g. x64-irsa, arm-pod-identity"
+  PodIdentityRoleArn:
+    Type: String
+    Default: ""
+  AuthType:
+    Type: String
+    AllowedValues: [irsa, pod-identity]
+  KubernetesVersion:
+    Type: String
+    Default: "1.35"
+  PublicAccessCidrs:
+    Type: CommaDelimitedList
+    Default: "0.0.0.0/0"
+    Description: "CIDR blocks allowed to access the EKS API endpoint"
+
+Conditions:
+  IsIRSA: !Equals [!Ref AuthType, irsa]
+  IsPodIdentity: !Equals [!Ref AuthType, pod-identity]
+
+Resources:
+  # ============================================================
+  # VPC & Networking
+  # ============================================================
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 192.168.0.0/16
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      Tags:
+        - Key: Name
+          Value: !Sub "${ClusterName}-vpc"
+
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+
+  VPCGatewayAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref VPC
+      InternetGatewayId: !Ref InternetGateway
+
+  PublicSubnetA:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: 192.168.0.0/19
+      AvailabilityZone: !Select [0, !GetAZs ""]
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: kubernetes.io/role/elb
+          Value: "1"
+
+  PublicSubnetB:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: 192.168.32.0/19
+      AvailabilityZone: !Select [1, !GetAZs ""]
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: kubernetes.io/role/elb
+          Value: "1"
+
+  PublicSubnetC:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: 192.168.64.0/19
+      AvailabilityZone: !Select [2, !GetAZs ""]
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: kubernetes.io/role/elb
+          Value: "1"
+
+  PublicRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+
+  PublicRoute:
+    Type: AWS::EC2::Route
+    DependsOn: VPCGatewayAttachment
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+
+  PublicSubnetARouteTableAssoc:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PublicSubnetA
+      RouteTableId: !Ref PublicRouteTable
+
+  PublicSubnetBRouteTableAssoc:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PublicSubnetB
+      RouteTableId: !Ref PublicRouteTable
+
+  PublicSubnetCRouteTableAssoc:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PublicSubnetC
+      RouteTableId: !Ref PublicRouteTable
+
+  NATIP:
+    Type: AWS::EC2::EIP
+    Properties:
+      Domain: vpc
+
+  NATGateway:
+    Type: AWS::EC2::NatGateway
+    Properties:
+      AllocationId: !GetAtt NATIP.AllocationId
+      SubnetId: !Ref PublicSubnetA
+
+  PrivateSubnetA:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: 192.168.96.0/19
+      AvailabilityZone: !Select [0, !GetAZs ""]
+      Tags:
+        - Key: kubernetes.io/role/internal-elb
+          Value: "1"
+
+  PrivateSubnetB:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: 192.168.128.0/19
+      AvailabilityZone: !Select [1, !GetAZs ""]
+      Tags:
+        - Key: kubernetes.io/role/internal-elb
+          Value: "1"
+
+  PrivateSubnetC:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: 192.168.160.0/19
+      AvailabilityZone: !Select [2, !GetAZs ""]
+      Tags:
+        - Key: kubernetes.io/role/internal-elb
+          Value: "1"
+
+  PrivateRouteTableA:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+
+  PrivateRouteTableB:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+
+  PrivateRouteTableC:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+
+  PrivateRouteA:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref PrivateRouteTableA
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId: !Ref NATGateway
+
+  PrivateRouteB:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref PrivateRouteTableB
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId: !Ref NATGateway
+
+  PrivateRouteC:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref PrivateRouteTableC
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId: !Ref NATGateway
+
+  PrivateSubnetARouteTableAssoc:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PrivateSubnetA
+      RouteTableId: !Ref PrivateRouteTableA
+
+  PrivateSubnetBRouteTableAssoc:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PrivateSubnetB
+      RouteTableId: !Ref PrivateRouteTableB
+
+  PrivateSubnetCRouteTableAssoc:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PrivateSubnetC
+      RouteTableId: !Ref PrivateRouteTableC
+
+  # ============================================================
+  # Security Groups
+  # ============================================================
+  ControlPlaneSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Communication between the control plane and worker nodegroups
+      VpcId: !Ref VPC
+
+  ClusterSharedNodeSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Communication between all nodes in the cluster
+      VpcId: !Ref VPC
+
+  IngressInterNodeGroupSG:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref ClusterSharedNodeSecurityGroup
+      SourceSecurityGroupId: !Ref ClusterSharedNodeSecurityGroup
+      Description: Allow nodes to communicate with each other (all ports)
+      IpProtocol: "-1"
+      FromPort: 0
+      ToPort: 65535
+
+  # ============================================================
+  # EKS Cluster
+  # ============================================================
+  ClusterServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: eks.amazonaws.com
+            Action:
+              - sts:AssumeRole
+              - sts:TagSession
+      ManagedPolicyArns:
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEKSClusterPolicy"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEKSVPCResourceController"
+
+  ControlPlane:
+    Type: AWS::EKS::Cluster
+    Properties:
+      Name: !Ref ClusterName
+      RoleArn: !GetAtt ClusterServiceRole.Arn
+      Version: !Ref KubernetesVersion
+      AccessConfig:
+        AuthenticationMode: API_AND_CONFIG_MAP
+        BootstrapClusterCreatorAdminPermissions: true
+      ComputeConfig:
+        Enabled: true
+        NodePools:
+          - general-purpose
+          - system
+        NodeRoleArn: !GetAtt AutoModeNodeRole.Arn
+      KubernetesNetworkConfig:
+        ElasticLoadBalancing:
+          Enabled: true
+      StorageConfig:
+        BlockStorage:
+          Enabled: true
+      ResourcesVpcConfig:
+        SecurityGroupIds:
+          - !Ref ControlPlaneSecurityGroup
+        SubnetIds:
+          - !Ref PublicSubnetA
+          - !Ref PublicSubnetB
+          - !Ref PublicSubnetC
+          - !Ref PrivateSubnetA
+          - !Ref PrivateSubnetB
+          - !Ref PrivateSubnetC
+        EndpointPublicAccess: true
+        EndpointPrivateAccess: true
+        PublicAccessCidrs: !Ref PublicAccessCidrs
+
+  IngressDefaultClusterToNodeSG:
+    Type: AWS::EC2::SecurityGroupIngress
+    DependsOn: ControlPlane
+    Properties:
+      GroupId: !Ref ClusterSharedNodeSecurityGroup
+      SourceSecurityGroupId: !GetAtt ControlPlane.ClusterSecurityGroupId
+      Description: Allow managed and unmanaged nodes to communicate with each other (all ports)
+      IpProtocol: "-1"
+      FromPort: 0
+      ToPort: 65535
+
+  IngressNodeToDefaultClusterSG:
+    Type: AWS::EC2::SecurityGroupIngress
+    DependsOn: ControlPlane
+    Properties:
+      GroupId: !GetAtt ControlPlane.ClusterSecurityGroupId
+      SourceSecurityGroupId: !Ref ClusterSharedNodeSecurityGroup
+      Description: Allow unmanaged nodes to communicate with control plane (all ports)
+      IpProtocol: "-1"
+      FromPort: 0
+      ToPort: 65535
+
+  # ============================================================
+  # Auto Mode Node Role
+  # ============================================================
+  AutoModeNodeRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ec2.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEKSWorkerNodeMinimalPolicy"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEC2ContainerRegistryPullOnly"
+
+  # ============================================================
+  # IRSA (only when AuthType=irsa)
+  # ============================================================
+  OIDCProvider:
+    Type: AWS::IAM::OIDCProvider
+    Condition: IsIRSA
+    DependsOn: ControlPlane
+    Properties:
+      Url: !GetAtt ControlPlane.OpenIdConnectIssuerUrl
+      ClientIdList:
+        - sts.amazonaws.com
+      # AWS ignores the thumbprint for EKS OIDC providers (it validates via
+      # the STS regional endpoint's CA instead). A value is still required by
+      # the CFN schema, so we provide a placeholder.
+      ThumbprintList:
+        - "0000000000000000000000000000000000000000"
+
+  IRSARole:
+    Type: AWS::IAM::Role
+    Condition: IsIRSA
+    DependsOn: OIDCProvider
+    Properties:
+      AssumeRolePolicyDocument: !Sub
+        - |
+          {
+            "Version": "2012-10-17",
+            "Statement": [{
+              "Effect": "Allow",
+              "Principal": {
+                "Federated": "arn:${AWS::Partition}:iam::${AWS::AccountId}:oidc-provider/${OIDCHost}"
+              },
+              "Action": "sts:AssumeRoleWithWebIdentity",
+              "Condition": {
+                "StringEquals": {
+                  "${OIDCHost}:aud": "sts.amazonaws.com",
+                  "${OIDCHost}:sub": "system:serviceaccount:kube-system:basic-test-mount-sa-${Suffix}"
+                }
+              }
+            }]
+          }
+        - OIDCHost: !Select
+            - 1
+            - !Split ["//", !GetAtt ControlPlane.OpenIdConnectIssuerUrl]
+      ManagedPolicyArns:
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonSSMReadOnlyAccess"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AWSSecretsManagerClientReadOnlyAccess"
+
+  # ============================================================
+  # Pod Identity (only when AuthType=pod-identity)
+  # ============================================================
+  PodIdentityAddon:
+    Type: AWS::EKS::Addon
+    Condition: IsPodIdentity
+    DependsOn: ControlPlane
+    Properties:
+      ClusterName: !Ref ClusterName
+      AddonName: eks-pod-identity-agent
+
+  PodIdentityAssociation:
+    Type: AWS::EKS::PodIdentityAssociation
+    Condition: IsPodIdentity
+    DependsOn: PodIdentityAddon
+    Properties:
+      ClusterName: !Ref ClusterName
+      Namespace: kube-system
+      ServiceAccount: !Sub "basic-test-mount-sa-${Suffix}"
+      RoleArn: !Ref PodIdentityRoleArn
+
+Outputs:
+  ClusterName:
+    Value: !Ref ClusterName
+  ClusterEndpoint:
+    Value: !GetAtt ControlPlane.Endpoint
+  ClusterCA:
+    Value: !GetAtt ControlPlane.CertificateAuthorityData
+  ClusterSecurityGroupId:
+    Value: !GetAtt ControlPlane.ClusterSecurityGroupId
+  OIDCIssuerUrl:
+    Value: !GetAtt ControlPlane.OpenIdConnectIssuerUrl
+  AutoModeNodeRoleArn:
+    Value: !GetAtt AutoModeNodeRole.Arn
+  IRSARoleArn:
+    Condition: IsIRSA
+    Value: !GetAtt IRSARole.Arn
+  VpcId:
+    Value: !Ref VPC

--- a/tests/cfn/test-resources.yaml
+++ b/tests/cfn/test-resources.yaml
@@ -1,0 +1,89 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >-
+  Test secrets and SSM parameters for integration tests.
+  Deployed once per region (primary + failover) using the same template.
+  Resource names must match those in templates/BasicTestMountSPC.yaml.template.
+
+Parameters:
+  Suffix:
+    Type: String
+    Description: "e.g. x64-irsa, arm-pod-identity"
+  ResourcePrefix:
+    Type: String
+    Default: ""
+    Description: "Inserted into resource names for collision avoidance (e.g. EKSAddon)"
+
+Resources:
+  # ============================================================
+  # Secrets Manager test secrets
+  # ============================================================
+  SecretsManagerTest1:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: !Sub "SecretsManagerTest1${ResourcePrefix}-${Suffix}"
+      SecretString: "SecretsManagerTest1Value"
+
+  SecretsManagerTest2:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: !Sub "SecretsManagerTest2${ResourcePrefix}-${Suffix}"
+      SecretString: "SecretsManagerTest2Value"
+
+  SecretsManagerSync:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: !Sub "SecretsManagerSync${ResourcePrefix}-${Suffix}"
+      SecretString: "SecretUser"
+
+  SecretsManagerRotation:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: !Sub "SecretsManagerRotationTest${ResourcePrefix}-${Suffix}"
+      SecretString: "BeforeRotation"
+
+  SecretsManagerJson:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: !Sub "secretsManagerJson${ResourcePrefix}-${Suffix}"
+      SecretString: '{"username": "SecretsManagerUser", "password": "PasswordForSecretsManager"}'
+
+  # ============================================================
+  # SSM Parameter Store test parameters
+  # ============================================================
+  ParameterStoreTest1:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "ParameterStoreTest1${ResourcePrefix}-${Suffix}"
+      Type: String
+      Value: "ParameterStoreTest1Value"
+
+  ParameterStoreTest2:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "ParameterStoreTestWithLongName${ResourcePrefix}-${Suffix}"
+      Type: String
+      Value: "ParameterStoreTest2Value"
+
+  ParameterStoreRotation:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "ParameterStoreRotationTest${ResourcePrefix}-${Suffix}"
+      Type: String
+      Value: "BeforeRotation"
+
+  ParameterStoreJson:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "jsonSsm${ResourcePrefix}-${Suffix}"
+      Type: String
+      Value: '{"username": "ParameterStoreUser", "password": "PasswordForParameterStore"}'
+
+  # Created as Type: String because CFN doesn't support SecureString without
+  # specifying a KMS key. The integration test overwrites this as SecureString
+  # via 'aws ssm put-parameter --type SecureString' to exercise that code path.
+  ParameterStoreSecureString:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "ParameterStoreSecureTest${ResourcePrefix}-${Suffix}"
+      Type: String
+      Value: "SecureStringTestValue"

--- a/tests/infra.sh
+++ b/tests/infra.sh
@@ -1,0 +1,398 @@
+#!/bin/bash
+#
+# Pluggable infrastructure backend for integration tests.
+#
+# Provides a uniform interface for creating and tearing down EKS test clusters
+# with two interchangeable backends:
+#
+#   cfn    — Fully declarative via CloudFormation (cluster + resources).
+#            No eksctl dependency. Best for constrained environments.
+#
+#   eksctl — Cluster creation via eksctl, test resources via CloudFormation.
+#            Best for quick local iteration and GitHub Actions.
+#
+# Both backends use CloudFormation for test secrets and SSM parameters
+# (cfn/test-resources.yaml), ensuring resource definitions are always
+# declarative and consistent.
+#
+# Usage: infra.sh <command> [args...]
+#
+# Commands:
+#   deploy <suffix>            Create cluster + test resources for a target
+#   delete <suffix>            Tear down cluster + test resources for a target
+#   cleanup-stale <suffix...>  Remove leftover resources from previous runs
+#   write-kubeconfig <suffix>  Write kubeconfig for an existing cluster
+#   print-regions              Output REGION/FAILOVERREGION as shell exports
+#
+# Environment:
+#   INFRA_BACKEND         cfn | eksctl | auto (default: auto — eksctl if available, else cfn)
+#   REGION                Primary AWS region (auto-detected if unset)
+#   FAILOVERREGION        Failover AWS region (auto-detected if unset)
+#   RESOURCE_PREFIX       Inserted into test resource names for collision avoidance (default: "")
+#   POD_IDENTITY_ROLE_ARN IAM role ARN for Pod Identity tests
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ============================================================
+# Configuration
+# ============================================================
+
+INFRA_BACKEND="${INFRA_BACKEND:-auto}"
+
+# Stack naming conventions:
+#   integ-cluster-<suffix>     — EKS cluster (cfn backend only; eksctl manages its own stacks)
+#   integ-resources-<suffix>   — test secrets/params in primary region
+#   integ-failover-<suffix>    — test secrets/params in failover region
+CLUSTER_STACK_PREFIX="integ-cluster"
+RESOURCES_STACK_PREFIX="integ-resources"
+FAILOVER_STACK_PREFIX="integ-failover"
+
+# Short alias for RESOURCE_PREFIX, used in CFN parameter overrides.
+P="${RESOURCE_PREFIX:-}"
+
+# ============================================================
+# Region detection
+# ============================================================
+
+# Determine primary and failover regions. Uses env vars if set, otherwise
+# reads the AWS CLI default region and picks a same-geography failover.
+detect_regions() {
+	if [[ -n "${REGION:-}" && -n "${FAILOVERREGION:-}" ]]; then return; fi
+	REGION="${REGION:-$(aws configure get region 2>/dev/null || echo us-west-2)}"
+	if [[ -z "${FAILOVERREGION:-}" ]]; then
+		# Pick the first region in the same geography (e.g. us-east-2 for us-west-2)
+		local prefix="${REGION%%-*}"
+		FAILOVERREGION=$(aws ec2 describe-regions --all-regions --query \
+			"Regions[?starts_with(RegionName,'${prefix}') && RegionName!='${REGION}'].RegionName | sort(@) | [0]" \
+			--output text --region "$REGION" 2>/dev/null) || true
+		if [[ -z "$FAILOVERREGION" || "$FAILOVERREGION" == "None" ]]; then
+			FAILOVERREGION="$REGION"
+		fi
+	fi
+}
+
+# ============================================================
+# CloudFormation helpers
+# ============================================================
+
+# Safely delete a CFN stack, handling all intermediate states:
+#   - Waits for any IN_PROGRESS operation to finish
+#   - Continues a failed rollback so the stack becomes deletable
+#   - Disables termination protection (test stacks shouldn't have it, but just in case)
+#   - Deletes and waits for completion
+wait_and_delete_stack() {
+	local stack="$1" region="$2" status
+	status=$(aws cloudformation describe-stacks --stack-name "$stack" --region "$region" \
+		--query 'Stacks[0].StackStatus' --output text 2>/dev/null) || return 0
+	if [[ "$status" == "DELETE_COMPLETE" ]]; then return 0; fi
+
+	# Wait for any in-progress operation before attempting delete.
+	# REVIEW_IN_PROGRESS means a changeset is awaiting approval — it won't resolve
+	# on its own, so we delete the stack directly instead of waiting.
+	while [[ "$status" == *"IN_PROGRESS"* && "$status" != "REVIEW_IN_PROGRESS" ]]; do
+		echo "⏳ $stack ($status)..."; sleep 10
+		status=$(aws cloudformation describe-stacks --stack-name "$stack" --region "$region" \
+			--query 'Stacks[0].StackStatus' --output text 2>/dev/null) || return 0
+	done
+
+	# A stuck rollback must be continued before the stack can be deleted
+	if [[ "$status" == *"ROLLBACK_FAILED"* ]]; then
+		aws cloudformation continue-update-rollback --stack-name "$stack" --region "$region" 2>/dev/null || true
+		aws cloudformation wait stack-rollback-complete --stack-name "$stack" --region "$region" 2>/dev/null || true
+	fi
+
+	aws cloudformation update-termination-protection --no-enable-termination-protection \
+		--stack-name "$stack" --region "$region" >/dev/null 2>&1 || true
+	aws cloudformation delete-stack --stack-name "$stack" --region "$region" >/dev/null 2>&1 || true
+	aws cloudformation wait stack-delete-complete --stack-name "$stack" --region "$region" 2>/dev/null || true
+
+	# If the stack landed in DELETE_FAILED, force-delete by retaining the
+	# resources that blocked deletion. This abandons those resources but
+	# unblocks the stack so subsequent deploys don't hit AlreadyExistsException.
+	status=$(aws cloudformation describe-stacks --stack-name "$stack" --region "$region" \
+		--query 'Stacks[0].StackStatus' --output text 2>/dev/null) || return 0
+	if [[ "$status" == "DELETE_FAILED" ]]; then
+		echo "⚠ $stack in DELETE_FAILED — retrying with --retain-resources"
+		local retain
+		retain=$(aws cloudformation describe-stack-resources --stack-name "$stack" --region "$region" \
+			--query 'StackResources[?ResourceStatus!=`DELETE_COMPLETE`].LogicalResourceId' --output text 2>/dev/null)
+		cleanup_retained_eips "$stack" "$region"
+		aws cloudformation delete-stack --stack-name "$stack" --region "$region" \
+			--retain-resources $retain >/dev/null 2>&1 || true
+		aws cloudformation wait stack-delete-complete --stack-name "$stack" --region "$region" 2>/dev/null || true
+	fi
+}
+
+# Clean up Elastic IPs and NAT Gateways retained after a force-delete.
+# When --retain-resources abandons VPC resources, EIPs continue to incur charges.
+cleanup_retained_eips() {
+	local stack="$1" region="$2" vpc_id
+	vpc_id=$(aws cloudformation describe-stack-resources --stack-name "$stack" --region "$region" \
+		--query "StackResources[?LogicalResourceId=='VPC'].PhysicalResourceId" --output text 2>/dev/null) || return 0
+	[[ -n "$vpc_id" && "$vpc_id" != "None" ]] || return 0
+
+	local nat_gws
+	nat_gws=$(aws ec2 describe-nat-gateways --filter "Name=vpc-id,Values=$vpc_id" \
+		--query "NatGateways[?State!='deleted'].[NatGatewayId,NatGatewayAddresses[0].AllocationId]" \
+		--output text --region "$region" 2>/dev/null) || return 0
+	local deleted_any=false
+	while read -r ngw alloc_id; do
+		[[ -n "$ngw" ]] || continue
+		echo "Deleting NAT Gateway $ngw and releasing EIP $alloc_id"
+		aws ec2 delete-nat-gateway --nat-gateway-id "$ngw" --region "$region" >/dev/null 2>&1 || true
+		deleted_any=true
+	done <<< "$nat_gws"
+	# Wait for NAT Gateways to release EIPs, then release them
+	if [[ "$deleted_any" == "true" ]]; then sleep 30; fi
+	while read -r ngw alloc_id; do
+		[[ -n "$alloc_id" && "$alloc_id" != "None" ]] || continue
+		aws ec2 release-address --allocation-id "$alloc_id" --region "$region" >/dev/null 2>&1 || true
+	done <<< "$nat_gws"
+}
+
+# Deploy test-resources.yaml to both primary and failover regions.
+# Used by both backends — test resources are always managed via CFN.
+# Before deploying, removes any pre-existing resources with the same names
+# that might have been created outside of CFN (e.g. by a previous test run
+# using imperative AWS CLI calls). CFN cannot create resources that already exist.
+deploy_test_resources() {
+	local suffix="$1"; detect_regions
+	local tpl="$SCRIPT_DIR/cfn/test-resources.yaml"
+	local params=("Suffix=$suffix" "ResourcePrefix=$P")
+
+	# Clean up any pre-existing resources that would conflict with CFN creation
+	cleanup_conflicting_resources "$suffix" "$REGION"
+	cleanup_conflicting_resources "$suffix" "$FAILOVERREGION"
+
+	echo "Deploying test resources in $REGION and $FAILOVERREGION..."
+	local expires_at
+	expires_at=$(date -u -d '+4 hours' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+		|| date -u -v+4H '+%Y-%m-%dT%H:%M:%SZ')
+	aws cloudformation deploy --template-file "$tpl" \
+		--stack-name "${RESOURCES_STACK_PREFIX}-${suffix}" \
+		--parameter-overrides "${params[@]}" \
+		--region "$REGION" --no-fail-on-empty-changeset \
+		--tags "ExpiresAt=$expires_at" "ManagedBy=integ-tests" &
+	local pid_primary=$!
+
+	aws cloudformation deploy --template-file "$tpl" \
+		--stack-name "${FAILOVER_STACK_PREFIX}-${suffix}" \
+		--parameter-overrides "${params[@]}" \
+		--region "$FAILOVERREGION" --no-fail-on-empty-changeset \
+		--tags "ExpiresAt=$expires_at" "ManagedBy=integ-tests" &
+	local pid_failover=$!
+
+	local failed=0
+	if ! wait "$pid_primary"; then echo "⚠ Test resource deploy failed in $REGION"; failed=1; fi
+	if ! wait "$pid_failover"; then echo "⚠ Test resource deploy failed in $FAILOVERREGION"; failed=1; fi
+	if [[ $failed -eq 1 ]]; then return 1; fi
+}
+
+# Remove secrets/parameters that exist outside of CFN management.
+# This handles the case where resources were created by a previous test run
+# using imperative CLI calls (e.g. the old Python test-manager) and would
+# cause CFN's ResourceExistenceCheck to fail.
+cleanup_conflicting_resources() {
+	local suffix="$1" region="$2"
+	source "$SCRIPT_DIR/resource-names.env"
+	for name in "${SECRET_NAMES[@]}"; do
+		aws secretsmanager delete-secret --secret-id "$name" --force-delete-without-recovery \
+			--region "$region" >/dev/null 2>&1 || true
+	done
+	for name in "${PARAM_NAMES[@]}"; do
+		aws ssm delete-parameter --name "$name" --region "$region" >/dev/null 2>&1 || true
+	done
+}
+
+# Delete test resource stacks from both regions (in parallel).
+# Also cleans up any resources that exist outside of CFN management.
+delete_test_resources() {
+	local suffix="$1"; detect_regions
+	echo "Cleaning up test secrets/parameters for $suffix..."
+	cleanup_conflicting_resources "$suffix" "$REGION"
+	cleanup_conflicting_resources "$suffix" "$FAILOVERREGION"
+	echo "Deleting test resource stacks for $suffix..."
+	wait_and_delete_stack "${RESOURCES_STACK_PREFIX}-${suffix}" "$REGION" &
+	local pid1=$!
+	wait_and_delete_stack "${FAILOVER_STACK_PREFIX}-${suffix}" "$FAILOVERREGION" &
+	local pid2=$!
+	wait "$pid1" "$pid2"
+	echo "✓ Test resources deleted for $suffix"
+}
+
+# ============================================================
+# Kubeconfig (shared by both backends)
+# ============================================================
+
+# Both backends use the same cluster naming convention (integ-cluster-<suffix>),
+# so kubeconfig generation is identical regardless of how the cluster was created.
+write_kubeconfig() {
+	local suffix="$1" kc="/tmp/integ-kubeconfig-${suffix}"
+	detect_regions
+	aws eks update-kubeconfig \
+		--name "${CLUSTER_STACK_PREFIX}-${suffix}" --region "$REGION" \
+		--kubeconfig "$kc" 2>/dev/null
+	chmod 600 "$kc"
+}
+
+# ============================================================
+# CFN backend
+# ============================================================
+# Deploys three stacks per target:
+#   1. cluster-stack.yaml (primary region) — VPC, EKS, nodes, auth
+#   2. test-resources.yaml (primary region) — test secrets/params
+#   3. test-resources.yaml (failover region) — replica of test secrets/params
+
+# Deploy cluster stack and test resource stacks.
+cfn_deploy() {
+	local suffix="$1"; detect_regions
+	local stack="${CLUSTER_STACK_PREFIX}-${suffix}" auth_type="${suffix#*-}"
+
+	echo "Deploying $stack (auth=$auth_type, auto mode)..."
+	local params=("ClusterName=$stack" "Suffix=$suffix" "AuthType=$auth_type" "KubernetesVersion=${EKS_VERSION:-1.35}")
+	if [[ "$auth_type" == "pod-identity" && -n "${POD_IDENTITY_ROLE_ARN:-}" ]]; then
+		params+=("PodIdentityRoleArn=$POD_IDENTITY_ROLE_ARN")
+	fi
+
+	local expires_at
+	expires_at=$(date -u -d '+4 hours' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+		|| date -u -v+4H '+%Y-%m-%dT%H:%M:%SZ')
+	aws cloudformation deploy --template-file "$SCRIPT_DIR/cfn/cluster-stack.yaml" \
+		--stack-name "$stack" --parameter-overrides "${params[@]}" \
+		--capabilities CAPABILITY_IAM --region "$REGION" --no-fail-on-empty-changeset \
+		--tags "ExpiresAt=$expires_at" "ManagedBy=integ-tests"
+
+	deploy_test_resources "$suffix"
+	echo "✓ Deployed $suffix"
+}
+
+# Delete cluster stack and test resource stacks.
+cfn_delete() {
+	local suffix="$1"; detect_regions
+	echo "Deleting stacks for $suffix..."
+	wait_and_delete_stack "${CLUSTER_STACK_PREFIX}-${suffix}" "$REGION" &
+	local cluster_pid=$!
+	delete_test_resources "$suffix"
+	local failed=0
+	if ! wait "$cluster_pid"; then
+		echo "⚠ Cluster stack deletion failed for $suffix"
+		failed=1
+	fi
+	if [[ $failed -eq 0 ]]; then
+		echo "✓ Deleted $suffix"
+	else
+		echo "✗ Deletion incomplete for $suffix"
+		return 1
+	fi
+}
+
+# Remove leftover stacks from previous test runs.
+cfn_cleanup_stale() {
+	detect_regions
+	for suffix in "$@"; do
+		for sr in \
+			"${CLUSTER_STACK_PREFIX}-${suffix}:${REGION}" \
+			"${RESOURCES_STACK_PREFIX}-${suffix}:${REGION}" \
+			"${FAILOVER_STACK_PREFIX}-${suffix}:${FAILOVERREGION}"; do
+			local stack="${sr%%:*}" region="${sr#*:}" status
+			status=$(aws cloudformation describe-stacks --stack-name "$stack" --region "$region" \
+				--query 'Stacks[0].StackStatus' --output text 2>/dev/null) || continue
+			if [[ "$status" != "DELETE_COMPLETE" ]]; then
+				echo "⚠ Cleaning up $stack ($status)..."
+				wait_and_delete_stack "$stack" "$region"
+			fi
+		done
+	done
+}
+
+# ============================================================
+# eksctl backend
+# ============================================================
+# Creates clusters imperatively via eksctl. Test secrets and SSM parameters
+# are still managed via CloudFormation (test-resources.yaml) for consistency.
+
+# Create cluster via eksctl with auto mode and deploy test resource stacks.
+eksctl_deploy() {
+	local suffix="$1"; detect_regions
+	local cluster="${CLUSTER_STACK_PREFIX}-${suffix}"
+
+	echo "Creating EKS cluster $cluster via eksctl (auto mode)..."
+	local version_flag=""
+	if [[ -n "${EKS_VERSION:-}" ]]; then version_flag="--version ${EKS_VERSION}"; fi
+	eksctl create cluster --name "$cluster" --region "$REGION" --enable-auto-mode \
+		$version_flag --kubeconfig="/tmp/integ-kubeconfig-${suffix}"
+
+	deploy_test_resources "$suffix"
+	echo "✓ Deployed $suffix"
+}
+
+# Delete test resource stacks and the eksctl cluster.
+eksctl_delete() {
+	local suffix="$1"; detect_regions
+	delete_test_resources "$suffix"
+	local cluster="${CLUSTER_STACK_PREFIX}-${suffix}"
+	echo "Deleting cluster ${cluster}..."
+	eksctl delete cluster --name "$cluster" --region "$REGION" --wait --force 2>/dev/null || true
+
+	# eksctl delete can fail partway through, leaving CFN stacks behind.
+	# Fall back to direct CFN deletion for any orphaned eksctl stacks.
+	local sn
+	aws cloudformation list-stacks --region "$REGION" \
+		--query "StackSummaries[?starts_with(StackName,'eksctl-${cluster}') && StackStatus!='DELETE_COMPLETE'].[StackName]" \
+		--output text 2>/dev/null | while read -r sn; do
+		if [[ -n "$sn" ]]; then
+			echo "⚠ Cleaning up orphaned stack $sn..."
+			wait_and_delete_stack "$sn" "$REGION"
+		fi
+	done
+	echo "✓ Deleted $suffix"
+}
+
+# Remove leftover EKS clusters, orphaned eksctl CFN stacks, and test resource stacks.
+eksctl_cleanup_stale() {
+	detect_regions
+	for suffix in "$@"; do
+		local name="${CLUSTER_STACK_PREFIX}-${suffix}" status
+
+		# Clean up the EKS cluster itself
+		status=$(aws eks describe-cluster --name "$name" --region "$REGION" \
+			--query 'cluster.status' --output text 2>/dev/null) || status=""
+		if [[ "$status" == "DELETING" ]]; then
+			echo "⏳ Cluster $name is deleting, waiting..."
+			aws eks wait cluster-deleted --name "$name" --region "$REGION" 2>/dev/null || true
+		elif [[ -n "$status" ]]; then
+			echo "⚠ Cluster $name exists ($status), deleting..."
+			eksctl delete cluster --name "$name" --region "$REGION" --wait 2>/dev/null || true
+		fi
+
+		# eksctl creates its own CFN stacks (eksctl-<cluster>-cluster, eksctl-<cluster>-nodegroup-*)
+		# that can be orphaned if eksctl delete fails partway through
+		aws cloudformation list-stacks --region "$REGION" \
+			--query "StackSummaries[?starts_with(StackName,'eksctl-${name}') && StackStatus!='DELETE_COMPLETE'].[StackName]" \
+			--output text 2>/dev/null | while read -r sn; do
+			if [[ -n "$sn" ]]; then wait_and_delete_stack "$sn" "$REGION"; fi
+		done
+
+		# Clean up test resource stacks
+		for sr in "${RESOURCES_STACK_PREFIX}-${suffix}:${REGION}" "${FAILOVER_STACK_PREFIX}-${suffix}:${FAILOVERREGION}"; do
+			local stack="${sr%%:*}" region="${sr#*:}"
+			wait_and_delete_stack "$stack" "$region"
+		done
+	done
+}
+
+# ============================================================
+# Dispatch
+# ============================================================
+
+case "${1:-}" in
+	print-regions)    detect_regions; echo "export REGION=\"$REGION\" FAILOVERREGION=\"$FAILOVERREGION\"" ;;
+	deploy)           "${INFRA_BACKEND}_deploy" "$2" ;;
+	delete)           "${INFRA_BACKEND}_delete" "$2" ;;
+	cleanup-stale)    shift; "${INFRA_BACKEND}_cleanup_stale" "$@" ;;
+	write-kubeconfig) write_kubeconfig "$2" ;;
+	*)                echo "Usage: infra.sh <deploy|delete|cleanup-stale|write-kubeconfig|print-regions> [args...]"; exit 1 ;;
+esac

--- a/tests/resource-names.env
+++ b/tests/resource-names.env
@@ -1,0 +1,27 @@
+# Canonical resource names for integration tests.
+# Sourced by infra.sh and integration.bats to keep names in sync.
+# Names use two variables that must be set before sourcing:
+#   P       — RESOURCE_PREFIX (collision avoidance, may be empty)
+#   suffix  — target identifier (e.g. x64-irsa)
+#
+# IMPORTANT: These names must match:
+#   - cfn/test-resources.yaml          (creates the resources)
+#   - templates/BasicTestMountSPC.yaml.template  (references them in the SPC)
+#   - integration.bats                 (asserts on mounted values)
+# If you add a resource, update ALL THREE files.
+
+SECRET_NAMES=(
+    "SecretsManagerTest1${P}-${suffix}"
+    "SecretsManagerTest2${P}-${suffix}"
+    "SecretsManagerSync${P}-${suffix}"
+    "SecretsManagerRotationTest${P}-${suffix}"
+    "secretsManagerJson${P}-${suffix}"
+)
+
+PARAM_NAMES=(
+    "ParameterStoreTest1${P}-${suffix}"
+    "ParameterStoreTestWithLongName${P}-${suffix}"
+    "ParameterStoreRotationTest${P}-${suffix}"
+    "jsonSsm${P}-${suffix}"
+    "ParameterStoreSecureTest${P}-${suffix}"
+)

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+#
+# One-time setup for integration tests.
+#
+# Usage: ./setup.sh [deps|iam|all]
+#
+#   deps — Check that required CLI tools are installed
+#   iam  — Create the IAM role needed for Pod Identity tests
+#   all  — Both (default)
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export PATH="${PATH}:${SCRIPT_DIR}/tools/bats/bin:${SCRIPT_DIR}/tools:${APOLLO_ENVIRONMENT_ROOT:-}/bin"
+ROLE_NAME="${POD_IDENTITY_ROLE_NAME:-pod-identity-role}"
+
+# ============================================================
+# Tool check
+# ============================================================
+
+# Check that all required CLI tools are installed; report optional ones.
+setup_deps() {
+    echo "Checking required tools..."
+    local missing=()
+    for tool in aws kubectl bats envsubst; do
+        if command -v "$tool" &>/dev/null; then
+            echo "  ✓ $tool ($(command -v "$tool"))"
+        else
+            missing+=("$tool")
+            echo "  ✗ $tool"
+        fi
+    done
+    # Optional tools — report presence but don't fail if missing
+    for tool in eksctl helm; do
+        if command -v "$tool" &>/dev/null; then
+            echo "  ✓ $tool ($(command -v "$tool")) [optional]"
+        else
+            echo "  - $tool [not found, optional]"
+        fi
+    done
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        echo ""
+        echo "Missing required tools: ${missing[*]}"
+        echo "  aws:      https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html"
+        echo "  kubectl:  https://kubernetes.io/docs/tasks/tools/"
+        echo "  bats:     https://github.com/bats-core/bats-core"
+        echo "  envsubst: Part of GNU gettext (brew install gettext / apt install gettext)"
+        exit 1
+    fi
+    echo "✓ All required tools available"
+}
+
+# ============================================================
+# Pod Identity IAM role
+# ============================================================
+
+# Creates an IAM role that EKS Pod Identity can assume. The role needs:
+#   - Trust policy allowing pods.eks.amazonaws.com to assume it
+#   - sts:TagSession (required by Pod Identity for session tagging)
+#   - Read-only policies for Secrets Manager and SSM Parameter Store
+setup_iam_role() {
+    local partition
+    partition=$(aws sts get-caller-identity --query Arn --output text | cut -d: -f2)
+    echo "Setting up IAM role for Pod Identity (partition: $partition)..."
+
+    if ! aws iam get-role --role-name "$ROLE_NAME" &>/dev/null; then
+        aws iam create-role --role-name "$ROLE_NAME" --assume-role-policy-document '{
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Principal": {"Service": "pods.eks.amazonaws.com"},
+                "Action": ["sts:AssumeRole", "sts:TagSession"]
+            }]
+        }' >/dev/null
+        echo "✓ Created role: $ROLE_NAME"
+    else
+        echo "✓ Role exists: $ROLE_NAME"
+    fi
+
+    for policy in AmazonSSMReadOnlyAccess AWSSecretsManagerClientReadOnlyAccess; do
+        aws iam attach-role-policy --role-name "$ROLE_NAME" \
+            --policy-arn "arn:${partition}:iam::aws:policy/${policy}" 2>/dev/null || true
+    done
+
+    local role_arn
+    role_arn=$(aws iam get-role --role-name "$ROLE_NAME" --query Role.Arn --output text)
+    echo ""
+    echo "Run:  export POD_IDENTITY_ROLE_ARN=$role_arn"
+}
+
+# ============================================================
+# Main
+# ============================================================
+
+cd "$SCRIPT_DIR"
+case "${1:-all}" in
+    deps) setup_deps ;;
+    iam)  setup_iam_role ;;
+    all)  setup_deps; setup_iam_role ;;
+    *)    echo "Usage: ./setup.sh [deps|iam|all]"; exit 1 ;;
+esac

--- a/tests/templates/BasicTestMount.yaml.template
+++ b/tests/templates/BasicTestMount.yaml.template
@@ -1,0 +1,32 @@
+# Test pod template.
+#
+# Deploys a minimal busybox pod that mounts secrets via the CSI driver.
+# The pod sleeps indefinitely so tests can exec into it to read mounted files.
+#
+# Variables (substituted by envsubst):
+#   ARCH, AUTH_TYPE  — used in naming to avoid collisions across parallel runs
+#   BUSYBOX_IMAGE    — container image for the test pod
+kind: Pod
+apiVersion: v1
+metadata:
+  name: basic-test-mount-${ARCH}-${AUTH_TYPE}
+spec:
+  serviceAccountName: basic-test-mount-sa-${ARCH}-${AUTH_TYPE}
+  containers:
+    - image: ${BUSYBOX_IMAGE}
+      name: busybox
+      imagePullPolicy: IfNotPresent
+      command:
+        - "/bin/sleep"
+        - "10000"
+      volumeMounts:
+        - name: secrets-store-inline
+          mountPath: "/mnt/secrets-store"
+          readOnly: true
+  volumes:
+    - name: secrets-store-inline
+      csi:
+        driver: secrets-store.csi.k8s.io
+        readOnly: true
+        volumeAttributes:
+          secretProviderClass: "basic-test-mount-spc-${ARCH}-${AUTH_TYPE}"

--- a/tests/templates/BasicTestMountSPC.yaml.template
+++ b/tests/templates/BasicTestMountSPC.yaml.template
@@ -1,0 +1,85 @@
+# SecretProviderClass template.
+#
+# Defines which secrets and parameters to mount, and how to sync them to K8s Secrets.
+# This is the core configuration that the CSI driver uses to fetch and mount secrets.
+#
+# Variables (substituted by envsubst):
+#   ARCH, AUTH_TYPE      — target identifiers for parallel run isolation
+#   RESOURCE_PREFIX      — collision avoidance prefix (empty by default)
+#   REGION, FAILOVERREGION, ACCOUNT_NUMBER — AWS context
+#   POD_IDENTITY_PARAM   — injected as 'usePodIdentity: "true"' or empty
+#
+# Resource naming convention:
+#   <BaseName>${RESOURCE_PREFIX}-${ARCH}-${AUTH_TYPE}
+#   e.g. "SecretsManagerTest1-x64-irsa" or "SecretsManagerTest1EKSAddon-x64-irsa"
+#
+# secretObjects: Syncs mounted secrets to native K8s Secrets. The objectName
+# fields here reference jmesPath aliases (ssmUsername, etc.) or full secret names.
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: basic-test-mount-spc-${ARCH}-${AUTH_TYPE}
+spec:
+  provider: aws
+  secretObjects:
+    - secretName: secret
+      type: Opaque
+      data:
+        - objectName: SecretsManagerSync${RESOURCE_PREFIX}-${ARCH}-${AUTH_TYPE}
+          key: username
+    - secretName: json-ssm
+      type: Opaque
+      data:
+        - objectName: ssmUsername
+          key: username
+        - objectName: ssmPassword
+          key: password
+    - secretName: secrets-manager-json
+      type: Opaque
+      data:
+        - objectName: secretsManagerUsername
+          key: username
+        - objectName: secretsManagerPassword
+          key: password
+
+  parameters:${POD_IDENTITY_PARAM}
+    region: ${REGION}
+    failoverRegion: ${FAILOVERREGION}
+    objects: |
+      # --- SSM Parameter Store secrets ---
+      - objectName: "ParameterStoreTest1${RESOURCE_PREFIX}-${ARCH}-${AUTH_TYPE}"
+        objectType: "ssmparameter"
+      - objectName: "ParameterStoreTestWithLongName${RESOURCE_PREFIX}-${ARCH}-${AUTH_TYPE}"
+        objectAlias: "ParameterStoreTest2${RESOURCE_PREFIX}"
+        objectType: "ssmparameter"
+      - objectName: "ParameterStoreRotationTest${RESOURCE_PREFIX}-${ARCH}-${AUTH_TYPE}"
+        objectType: "ssmparameter"
+      - objectName: "ParameterStoreSecureTest${RESOURCE_PREFIX}-${ARCH}-${AUTH_TYPE}"
+        objectType: "ssmparameter"
+      # --- Secrets Manager secrets ---
+      - objectName: "SecretsManagerRotationTest${RESOURCE_PREFIX}-${ARCH}-${AUTH_TYPE}"
+        objectType: "secretsmanager"
+      - objectName: "SecretsManagerTest1${RESOURCE_PREFIX}-${ARCH}-${AUTH_TYPE}"
+        objectType: "secretsmanager"
+      # SecretsManagerTest2 uses a full ARN + failoverObject for cross-region failover testing
+      - objectName: arn:aws:secretsmanager:${REGION}:${ACCOUNT_NUMBER}:secret:SecretsManagerTest2${RESOURCE_PREFIX}-${ARCH}-${AUTH_TYPE}
+        objectAlias: "SecretsManagerTest2${RESOURCE_PREFIX}"
+        failoverObject:
+          objectName: arn:aws:secretsmanager:${FAILOVERREGION}:${ACCOUNT_NUMBER}:secret:SecretsManagerTest2${RESOURCE_PREFIX}-${ARCH}-${AUTH_TYPE}
+      - objectName: "SecretsManagerSync${RESOURCE_PREFIX}-${ARCH}-${AUTH_TYPE}"
+        objectType: "secretsmanager"
+      # --- JMES path extraction (JSON secrets split into individual key files) ---
+      - objectName: "jsonSsm${RESOURCE_PREFIX}-${ARCH}-${AUTH_TYPE}"
+        objectType: "ssmparameter"
+        jmesPath:
+            - Path: "username"
+              ObjectAlias: "ssmUsername"
+            - Path: "password"
+              ObjectAlias: "ssmPassword"
+      - objectName: "secretsManagerJson${RESOURCE_PREFIX}-${ARCH}-${AUTH_TYPE}"
+        objectType: "secretsmanager"
+        jmesPath:
+            - Path: "username"
+              ObjectAlias: "secretsManagerUsername"
+            - Path: "password"
+              ObjectAlias: "secretsManagerPassword"


### PR DESCRIPTION
## Issue #, if available:

N/A — part of test framework migration from Python code-generation to shell-based unified framework.

## Description of changes:

Add CloudFormation templates, shell-based infrastructure backend, setup script, and supporting config files for the new unified integration test framework. **Additive only — no existing files are modified or deleted.**

New files:
- `tests/cfn/cluster-stack.yaml` — EKS Auto Mode cluster with VPC, IRSA, and Pod Identity. Parameterized K8s version and API access CIDRs.
- `tests/cfn/test-resources.yaml` — Test secrets and SSM parameters deployed to both primary and failover regions via CloudFormation. Replaces boto3-based secret creation.
- `tests/templates/BasicTestMount.yaml.template` — Test pod spec using envsubst variables. Replaces the `{{VAR}}` Python template.
- `tests/templates/BasicTestMountSPC.yaml.template` — SecretProviderClass with failover objects, JMES path extraction, and K8s Secret sync.
- `tests/infra.sh` — Pluggable infrastructure backend (cfn/eksctl). Handles CFN stack lifecycle, test resource deployment to both regions, stale resource cleanup, EIP cleanup on force-delete, and TTL tags on all stacks.
- `tests/setup.sh` — One-time setup: tool check, IAM role creation for Pod Identity.
- `tests/resource-names.env` — Canonical resource names sourced by infra.sh for cleanup consistency.
- `tests/addon_config_values.yaml` — EKS addon config exercising all schema properties.

PR chain: **1/4** → [#580](https://github.com/aws/secrets-store-csi-driver-provider-aws/pull/580) Delete old test files → [#581](https://github.com/aws/secrets-store-csi-driver-provider-aws/pull/581) Add new orchestrator + tests → [#582](https://github.com/aws/secrets-store-csi-driver-provider-aws/pull/582) Update CI workflow

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.