### PR TITLE
chore: add unified test orchestrator and integration tests [3/4]

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,47 +1,144 @@
-## Running prow tests
+## Running integration tests
 
-1. Complete the [Private Builds](https://github.com/aws/secrets-store-csi-driver-provider-aws/tree/main#private-builds) section of the README.
-2. Install [bats](https://github.com/bats-core/bats-core).
-3. If running multi-arch/multi-auth tests, install GNU Parallel (`brew install parallel`).
-4. Ensure that the `PRIVREPO` environment variable is set.
-5. You can set the `NODE_TYPE_*` environment variables to specify the EC2 instance types used for the test clusters (default: `m5.large` for x64, `m6g.large` for ARM).
-6. Create the following two IAM roles:
+### Quick start
+
+1. `cd` into the `tests/` directory.
+2. Run the setup script:
 
 ```bash
-export POD_IDENTITY_ROLE_ARN=$(aws --region "$REGION" --query Role.Arn --output text iam create-role --role-name pod-identity-role --assume-role-policy-document '{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Principal": {
-                "Service": "pods.eks.amazonaws.com"
-            },
-            "Action": [
-                "sts:AssumeRole",
-                "sts:TagSession"
-            ]
-        }
-    ]
-}')
+./setup.sh
 ```
 
-7. Attach the following policies to the role:
+This will check required tools and create the IAM role for Pod Identity tests.
+
+Subcommands: `./setup.sh deps` (tool check only), `./setup.sh iam` (IAM role only),
+`./setup.sh all` (both — default).
+
+3. Run the `export POD_IDENTITY_ROLE_ARN=...` command output by the setup script.
+4. Run `./run-tests.sh`
+
+### How it works
+
+The test suite creates real EKS clusters, provisions test secrets in Secrets Manager
+and SSM Parameter Store, installs the CSI driver + provider, deploys a test pod, and
+verifies that secrets appear as mounted files. The full lifecycle is:
+
+1. **`run-tests.sh`** validates configuration, runs preflight checks, and deploys
+   infrastructure for each target (arch × auth type) in parallel via `infra.sh`.
+2. **`infra.sh`** creates the cluster using either CloudFormation templates or eksctl
+   commands, depending on the `INFRA_BACKEND` setting. Both backends use CloudFormation
+   for test secrets and SSM parameters (`cfn/test-resources.yaml`).
+3. **`integration.bats`** runs the actual test cases: installs the driver/provider,
+   deploys a SecretProviderClass and test pod, then verifies reads, rotation, JMES
+   path extraction, K8s Secret sync, cross-region failover, SecureString parameters,
+   and error handling for invalid configurations.
+4. After tests complete, `run-tests.sh` dumps logs and tears down all infrastructure.
+
+### Architecture
+
+The test suite is designed to work across three environments using pluggable backends:
+
+| Setting | GitHub Actions | Local dev | Ops box |
+|---|---|---|---|
+| `INFRA_BACKEND` | `eksctl` | `eksctl` or `cfn` | `cfn` |
+| `INSTALL_METHOD` | `helm` | `helm` | `addon` |
+| `RESOURCE_PREFIX` | _(empty)_ | _(empty)_ | set per environment |
+| `PRIVREPO` | ghcr.io build | local ECR | _(unset)_ |
+
+**Infrastructure backends:**
+
+- **`eksctl`** — Creates EKS clusters via eksctl, test secrets/parameters via CloudFormation (`cfn/test-resources.yaml`). Requires `eksctl`.
+- **`cfn`** — Creates everything via CloudFormation (`cfn/cluster-stack.yaml` + `cfn/test-resources.yaml`). No eksctl dependency. Best for constrained environments.
+- **`auto`** (default) — Uses eksctl if available, otherwise cfn.
+
+**Install methods:**
+
+- **`addon`** — Installs the provider via EKS add-on (includes CSI driver). No `PRIVREPO` needed.
+- **`helm`** — Installs the CSI driver via Helm, then the provider via YAML manifest with a custom image. Requires `PRIVREPO`.
+- **`yaml`** — Applies the provider YAML manifest only (skips Helm CSI driver install). For environments where the CSI driver is already installed. Requires `PRIVREPO`.
+- **`auto`** (default) — Uses helm if `PRIVREPO` is set, otherwise addon.
+
+### Test targets
+
+| Command | What runs |
+|---|---|
+| `./run-tests.sh` | All 4 test combos in parallel |
+| `./run-tests.sh all` | Same as above (explicit) |
+| `./run-tests.sh x64` | x64-irsa + x64-pod-identity |
+| `./run-tests.sh arm` | arm-irsa + arm-pod-identity |
+| `./run-tests.sh irsa` | x64-irsa + arm-irsa |
+| `./run-tests.sh pod-identity` | x64-pod-identity + arm-pod-identity |
+| `./run-tests.sh x64-irsa` | Single test |
+
+### Flags
+
+- `--version <ver>` — Specify EKS add-on version (only for addon install method)
+- `--skip-deploy` — Skip infrastructure deployment (reuse existing clusters)
+- `--skip-cleanup` — Skip infrastructure teardown after tests
+- `--filter <regex>` — Run only tests matching the regex (passed to `bats --filter`)
+
+### Cleanup
 
 ```bash
-aws iam attach-role-policy \
-	--role-name pod-identity-role \
-	--policy-arn arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess
-aws iam attach-role-policy \
-	--role-name pod-identity-role \
-	--policy-arn arn:aws:iam::aws:policy/SecretsManagerReadWrite
+./run-tests.sh clean              # Clean all clusters/stacks
+./run-tests.sh clean x64-irsa     # Clean specific target
+./run-tests.sh clean arm          # Clean target group (accepts same shorthands as run)
 ```
 
-8. `cd` into the `tests` directory.
-9. Run `./run-tests.sh`
-   - Running the script without any arguments will run all 4 test cases in parallel (x64 + IRSA, x64 + Pod Identity, ARM + IRSA, ARM + Pod Identity)
-   - `./run-tests.sh x64` will run only x64 tests
-   - `./run-tests.sh arm` will run only ARM tests
-   - `./run-tests.sh x64-irsa` will run only x64 IRSA tests
-   - `./run-tests.sh x64-pod-identity` will run only x64 Pod Identity tests
-   - `./run-tests.sh arm-irsa` will run only ARM IRSA tests
-   - `./run-tests.sh arm-pod-identity` will run only ARM Pod Identity tests
+### What happens automatically
+
+Before running tests, `run-tests.sh` performs preflight checks:
+
+- Verifies required tools (conditional on backend/install method)
+- Validates AWS credentials (and optional account allowlist via `ALLOWED_ACCOUNTS_FILE`)
+- Cleans up stale resources from previous runs
+- Detects concurrent test runs (warns if other `integ-cluster-*` stacks exist)
+- Warns if `FAILOVERREGION` equals `REGION` (failover tests won't exercise cross-region behavior)
+- Checks VPC capacity (each target creates one VPC)
+
+After tests complete, logs are dumped to stdout (for CI) and saved to `tests/logs/<timestamp>/`.
+
+If any test fails, diagnostics (pod status, provider logs, events) are captured in the
+log output, and remaining tests in that target are skipped (fail-fast). Other targets
+running in parallel are not affected and continue independently.
+
+### Environment variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `INFRA_BACKEND` | No | `cfn`, `eksctl`, or `auto` (default) |
+| `INSTALL_METHOD` | No | `addon`, `helm`, `yaml`, or `auto` (default) |
+| `RESOURCE_PREFIX` | No | Prefix for test resource names (collision avoidance) |
+| `PRIVREPO` | For helm/yaml | Container image URI for the provider |
+| `PRIVTAG` | No | Image tag (appended to PRIVREPO with `:`) |
+| `PROVIDER_YAML` | No | Path to provider DaemonSet YAML (default: `../deployment/private-installer.yaml`) |
+| `POD_IDENTITY_ROLE_ARN` | For pod-identity | IAM role ARN for Pod Identity |
+| `POD_IDENTITY_ROLE_NAME` | No | IAM role name for Pod Identity (default: `pod-identity-role`, used by `setup.sh`) |
+| `REGION` | No | Primary AWS region (auto-detected) |
+| `FAILOVERREGION` | No | Failover region (auto-detected from same geography) |
+| `ADDON_VERSION` | No | EKS add-on version |
+| `ALLOWED_ACCOUNTS_FILE` | No | Path to file with allowed AWS account IDs (one per line) |
+| `EKS_VERSION` | No | Kubernetes version for EKS cluster (default: `1.35`, CFN backend only) |
+| `GHCR_TOKEN` | No | GitHub Container Registry token for pulling test images |
+
+### File structure
+
+```
+tests/
+├── cfn/
+│   ├── cluster-stack.yaml          # VPC + EKS + auth (CFN backend)
+│   └── test-resources.yaml         # Test secrets/params, deployed to both regions
+├── templates/
+│   ├── BasicTestMount.yaml.template    # Test pod spec (envsubst)
+│   └── BasicTestMountSPC.yaml.template # SecretProviderClass spec (envsubst)
+├── tools/                          # Vendored binaries (bats, kubectl) — gitignored
+│   └── .gitkeep
+├── infra.sh                        # Pluggable infra backend (cfn or eksctl)
+├── integration.bats                # Test cases (bats)
+├── helpers.bash                    # bats assertion helpers
+├── run-tests.sh                    # Test orchestrator (preflight → deploy → test → cleanup)
+├── setup.sh                        # One-time setup (tool check + IAM role)
+├── addon_config_values.yaml        # EKS addon config exercising all schema properties
+├── resource-names.env              # Canonical test resource names (sourced by infra.sh)
+└── README.md
+```

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -1,5 +1,9 @@
-#!/bin/bash
+# bats test helpers.
+#
+# bats provides $status and $output after `run` commands, but doesn't ship
+# assert_success by default. This file provides it for use in test assertions.
 
+# Assert that the most recent `run` command exited with status 0.
 assert_success() {
   if [[ "$status" != 0 ]]; then
     echo "expected: 0"
@@ -9,80 +13,21 @@ assert_success() {
   fi
 }
 
+# Assert that the most recent `run` command exited with non-zero status.
 assert_failure() {
   if [[ "$status" == 0 ]]; then
-    echo "expected: non-zero exit code"
+    echo "expected: non-zero"
     echo "actual: $status"
     echo "output: $output"
     return 1
   fi
 }
 
-assert_equal() {
-  if [[ "$1" != "$2" ]]; then
-    echo "expected: $1"
-    echo "actual: $2"
+# Assert that the most recent `run` output contains the given string.
+assert_output_contains() {
+  if [[ "$output" != *"$1"* ]]; then
+    echo "expected output to contain: $1"
+    echo "actual: $output"
     return 1
   fi
-}
-
-assert_not_equal() {
-  if [[ "$1" == "$2" ]]; then
-    echo "unexpected: $1"
-    echo "actual: $2"
-    return 1
-  fi
-}
-
-assert_match() {
-  if [[ ! "$2" =~ $1 ]]; then
-    echo "expected: $1"
-    echo "actual: $2"
-    return 1
-  fi
-}
-
-assert_not_match() {
-  if [[ "$2" =~ $1 ]]; then
-    echo "expected: $1"
-    echo "actual: $2"
-    return 1
-  fi
-}
-
-wait_for_process(){
-  wait_time="$1"
-  sleep_time="$2"
-  cmd="$3"
-  while [ "$wait_time" -gt 0 ]; do
-    if eval "$cmd"; then
-      return 0
-    else
-      sleep "$sleep_time"
-      wait_time=$((wait_time-sleep_time))
-    fi
-  done
-  return 1
-}
-
-compare_owner_count() {
-  secret="$1"
-  namespace="$2"
-  ownercount="$3"
-
-  [[ "$(kubectl get secret ${secret} -n ${namespace} -o json | jq '.metadata.ownerReferences | length')" -eq $ownercount ]]
-}
-
-check_secret_deleted() {
-  secret="$1"
-  namespace="$2"
-  kubeconfig_file="$3"
-
-  if [[ -z "$kubeconfig_file" ]]; then
-    result=$(kubectl get secret -n ${namespace} | grep "^${secret}$" | wc -l)
-  else
-    result=$(kubectl --kubeconfig="$kubeconfig_file" get secret -n ${namespace} | grep "^${secret}$" | wc -l)
-  fi
-
-  [[ "$result" -eq 0 ]]
 }

--- a/tests/integration.bats
+++ b/tests/integration.bats
@@ -1,0 +1,562 @@
+#!/usr/bin/env bats
+
+# Integration tests for AWS Secrets Store CSI Driver Provider.
+#
+# These tests verify that secrets from Secrets Manager and parameters from
+# SSM Parameter Store can be mounted into pods via the CSI driver. Tests cover:
+#   - Basic secret/parameter reads
+#   - Secret rotation (value changes reflected after CSI driver rotation interval)
+#   - JMES path extraction (mounting individual JSON keys as separate files)
+#   - Kubernetes Secret sync (CSI driver syncs mounted secrets to K8s Secrets)
+#   - Cross-region failover (secrets fetched from failover region on primary failure)
+#
+# Required env vars: ARCH, AUTH_TYPE, REGION, FAILOVERREGION
+# Optional: INSTALL_METHOD, INFRA_BACKEND, RESOURCE_PREFIX, ADDON_VERSION,
+#           PRIVREPO, PRIVTAG, POD_IDENTITY_ROLE_ARN, GHCR_TOKEN
+
+load helpers
+
+# ============================================================
+# Configuration
+# ============================================================
+
+BATS_TEST_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")" && pwd)"
+export PATH="${PATH}:${BATS_TEST_DIR}/tools/bats/bin:${BATS_TEST_DIR}/tools:${APOLLO_ENVIRONMENT_ROOT:-}/bin"
+
+WAIT=30s
+WAIT_LONG=300s
+export BUSYBOX_IMAGE="public.ecr.aws/docker/library/busybox:1.36"
+# Path to the provider DaemonSet YAML, used by the helm/yaml install method.
+# Defaults to the location within the OSS repo; override via env var when
+# running from a different directory.
+PROVIDER_YAML="${PROVIDER_YAML:-../deployment/private-installer.yaml}"
+NAMESPACE=kube-system
+
+# Naming convention: all test resources include ARCH and AUTH_TYPE to allow
+# parallel test runs in the same account without collisions.
+CLUSTER_NAME="integ-cluster-${ARCH}-${AUTH_TYPE}"
+POD_NAME="basic-test-mount-${ARCH}-${AUTH_TYPE}"
+SA_NAME="basic-test-mount-sa-${ARCH}-${AUTH_TYPE}"
+
+# RESOURCE_PREFIX is inserted into secret/parameter names for collision avoidance
+# across different test suites sharing the same account. Exported for envsubst
+# to interpolate in the SecretProviderClass YAML template.
+# P is a short alias used in test assertions to keep lines readable.
+export RESOURCE_PREFIX="${RESOURCE_PREFIX:-}"
+P="$RESOURCE_PREFIX"
+
+# These must be set by run-tests.sh before invoking bats.
+: "${INSTALL_METHOD:?must be set by run-tests.sh (addon, helm, or yaml)}"
+: "${INFRA_BACKEND:?must be set by run-tests.sh (cfn or eksctl)}"
+
+# Account number is needed in the SPC template for constructing full secret ARNs
+export ACCOUNT_NUMBER
+ACCOUNT_NUMBER=$(aws --region "$REGION" sts get-caller-identity --query Account --output text) || {
+	echo "Error: Failed to fetch AWS account number. Check credentials and REGION ($REGION)." >&2
+	exit 1
+}
+
+# ============================================================
+# Logging
+# ============================================================
+# Each arch-auth combo gets a distinct color so parallel log output is distinguishable.
+
+case "${ARCH}-${AUTH_TYPE}" in
+	x64-irsa) LOG_COLOR='\033[0;36m' ;; x64-pod-identity) LOG_COLOR='\033[0;35m' ;;
+	arm-irsa) LOG_COLOR='\033[0;34m' ;; arm-pod-identity) LOG_COLOR='\033[0;33m' ;;
+	*)        LOG_COLOR='\033[0m' ;;
+esac
+NC='\033[0m'
+
+# Log a message with color-coded prefix for the current arch-auth combo.
+log() { echo -e "${LOG_COLOR}[$(date -Iseconds)] [${ARCH}-${AUTH_TYPE}] $1${NC}" >&3; }
+
+# ============================================================
+# Kubectl helper
+# ============================================================
+
+# Run kubectl against the test cluster with the correct kubeconfig and namespace.
+kctl() { kubectl --kubeconfig="$KUBECONFIG_FILE" --namespace "$NAMESPACE" "$@"; }
+
+# ============================================================
+# CloudFormation helper
+# ============================================================
+
+# Retrieve a single output value from the cluster's CloudFormation stack.
+get_stack_output() {
+	aws cloudformation describe-stacks --stack-name "$CLUSTER_NAME" --region "$REGION" \
+		--query "Stacks[0].Outputs[?OutputKey=='${1}'].OutputValue" --output text
+}
+
+# ============================================================
+# Exported variables for envsubst (used in YAML templates)
+# ============================================================
+# POD_IDENTITY_PARAM is injected into the SecretProviderClass template.
+# When using Pod Identity, it adds 'usePodIdentity: "true"' to the parameters block.
+if [[ "$AUTH_TYPE" == "pod-identity" ]]; then
+	export POD_IDENTITY_PARAM=$'\n    usePodIdentity: "true"'
+else
+	export POD_IDENTITY_PARAM=""
+fi
+
+export KUBECONFIG_FILE="/tmp/integ-kubeconfig-${ARCH}-${AUTH_TYPE}"
+FAIL_MARKER="/tmp/integ-failfast-${ARCH}-${AUTH_TYPE}"
+
+# ============================================================
+# Auth setup
+# ============================================================
+# How auth is configured depends on the infrastructure backend:
+#
+# CFN backend: The IRSA role and Pod Identity association are created by the
+#   CloudFormation stack. We just need to create the K8s ServiceAccount and
+#   annotate it with the role ARN from the stack outputs.
+#
+# eksctl backend: We use eksctl commands to create the OIDC provider, IAM
+#   service account (IRSA), or Pod Identity addon + association imperatively.
+
+# Configure pod authentication (IRSA or Pod Identity) for the test service account.
+setup_auth() {
+	if [[ "$INFRA_BACKEND" == "cfn" ]]; then
+		log "Creating K8s ServiceAccount ($AUTH_TYPE)"
+		kctl create serviceaccount "$SA_NAME" --dry-run=client -o yaml | kctl apply -f - >&3 2>&1
+		if [[ "$AUTH_TYPE" == "irsa" ]]; then
+			# Read the IRSA role ARN that the CFN stack created
+			local irsa_role_arn
+			irsa_role_arn=$(get_stack_output "IRSARoleArn")
+			kctl annotate serviceaccount "$SA_NAME" "eks.amazonaws.com/role-arn=$irsa_role_arn" --overwrite >&3 2>&1
+		fi
+		# Pod Identity: no K8s-side setup needed — the CFN stack created the association
+	else
+		local partition
+		partition=$(aws sts get-caller-identity --query Arn --output text | cut -d: -f2)
+		if [[ "$AUTH_TYPE" == "irsa" ]]; then
+			log "Associating IAM OIDC provider"
+			eksctl utils associate-iam-oidc-provider --cluster "$CLUSTER_NAME" --approve --region "$REGION" >&3 2>&1
+			log "Creating IAM service account for IRSA"
+			eksctl create iamserviceaccount \
+				--name "$SA_NAME" --namespace "$NAMESPACE" --cluster "$CLUSTER_NAME" \
+				--attach-policy-arn "arn:${partition}:iam::aws:policy/AmazonSSMReadOnlyAccess" \
+				--attach-policy-arn "arn:${partition}:iam::aws:policy/AWSSecretsManagerClientReadOnlyAccess" \
+				--override-existing-serviceaccounts --approve --region "$REGION" >&3 2>&1
+		else
+			log "Creating EKS Pod Identity addon"
+			eksctl create addon --name eks-pod-identity-agent --cluster "$CLUSTER_NAME" --region "$REGION" --wait >&3 2>&1
+			log "Creating Pod Identity association"
+			eksctl create podidentityassociation \
+				--cluster "$CLUSTER_NAME" --namespace "$NAMESPACE" --region "$REGION" \
+				--service-account-name "$SA_NAME" --role-arn "$POD_IDENTITY_ROLE_ARN" \
+				--create-service-account true >&3 2>&1
+		fi
+	fi
+}
+
+# ============================================================
+# Driver/provider installation
+# ============================================================
+# Three install methods:
+#   addon — Install via EKS add-on (includes both CSI driver and provider)
+#   helm  — Install CSI driver via Helm, then provider via YAML manifest (test below)
+#   yaml  — Same as helm (the provider YAML is applied in the "Install aws provider" test)
+
+# Install the CSI driver and/or provider based on the selected install method.
+install_driver() {
+	if [[ "$INSTALL_METHOD" == "addon" ]]; then
+		local version_flag=""
+		if [[ -n "${ADDON_VERSION:-}" ]]; then
+			version_flag="--addon-version $ADDON_VERSION"
+		fi
+		log "Installing via EKS addon"
+		aws eks create-addon --cluster-name "$CLUSTER_NAME" --addon-name aws-secrets-store-csi-driver-provider \
+			--configuration-values "file://addon_config_values.yaml" $version_flag --region "$REGION" >&3 2>&1
+		aws eks wait addon-active --cluster-name "$CLUSTER_NAME" --addon-name aws-secrets-store-csi-driver-provider \
+			--region "$REGION" >&3 2>&1
+	elif [[ "$INSTALL_METHOD" == "helm" ]]; then
+		# Helm installs only the CSI driver. The provider itself is installed
+		# in the "Install aws provider" test case using the PRIVREPO image.
+		log "Installing secrets-store-csi-driver via Helm"
+		helm repo add secrets-store-csi-driver https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts
+		KUBECONFIG="$KUBECONFIG_FILE" helm --namespace="$NAMESPACE" install csi-secrets-store \
+			secrets-store-csi-driver/secrets-store-csi-driver \
+			--set enableSecretRotation=true --set rotationPollInterval=15s --set syncSecret.enabled=true \
+			--set tokenRequests[0].audience=sts.amazonaws.com --set tokenRequests[1].audience=pods.eks.amazonaws.com \
+			--timeout "$WAIT_LONG" --wait
+	fi
+}
+
+# ============================================================
+# bats lifecycle
+# ============================================================
+
+# One-time setup: write kubeconfig, wait for nodes, install driver, configure auth.
+setup_file() {
+	rm -f "$FAIL_MARKER"
+	log "Setting up $CLUSTER_NAME"
+
+	# Write kubeconfig for the cluster (created by run-tests.sh via infra.sh deploy)
+	bash infra.sh write-kubeconfig "${ARCH}-${AUTH_TYPE}" >&3 2>&1
+
+	# Wait for nodes — fast no-op if nodes are already Ready (cfn stacks take
+	# long enough that nodes are usually ready), but necessary as a safety net
+	kctl wait --for=condition=Ready node --all --timeout="$WAIT_LONG" >&3 2>&1
+
+	if ! install_driver; then
+		log "ERROR: install_driver failed"
+		touch "$FAIL_MARKER"
+		return 1
+	fi
+	if ! setup_auth; then
+		log "ERROR: setup_auth failed"
+		touch "$FAIL_MARKER"
+		return 1
+	fi
+
+	# Pull secret for private test images hosted on ghcr.io (GitHub Actions only)
+	if [[ -n "${GHCR_TOKEN:-}" ]]; then
+		log "Creating ghcr.io image pull secret"
+		kctl create secret docker-registry ghcr-credentials \
+			--docker-server=ghcr.io --docker-username=github --docker-password="$GHCR_TOKEN"
+	fi
+
+	log "Setup completed"
+}
+
+# Skip remaining tests if a previous test in this file failed (fail-fast).
+setup() {
+	if [[ -f "$FAIL_MARKER" ]]; then skip "Skipped due to earlier failure"; fi
+}
+
+# On test failure, dump diagnostics before skipping remaining tests (fail-fast).
+# This captures pod status, provider logs, and cluster events for debugging.
+teardown() {
+	if [[ "$BATS_TEST_COMPLETED" == "1" ]]; then return; fi
+	touch "$FAIL_MARKER"
+	log "FAILED: ${BATS_TEST_DESCRIPTION} — dumping diagnostics"
+	echo "# ===== BEGIN DIAGNOSTICS =====" >&3
+	{ echo "# --- pod status ---"
+	  kctl get pods -o wide 2>&1 | sed 's/^/#   /'; } >&3 || true
+	echo "# --- provider pods ---" >&3
+	for pod in $(kctl get pods -l app=csi-secrets-store-provider-aws -o name 2>/dev/null); do
+		{ echo "# describe $pod:"
+		  kctl describe "$pod" 2>&1 | tail -20 | sed 's/^/#   /'; } >&3 || true
+		{ echo "# logs $pod:"
+		  kctl logs "$pod" --tail=20 2>&1 | sed 's/^/#   /'; } >&3 || true
+	done
+	{ echo "# --- test pod ---"
+	  kctl describe "pod/$POD_NAME" 2>&1 | tail -20 | sed 's/^/#   /'; } >&3 || true
+	{ echo "# --- events ---"
+	  kctl get events --sort-by=.lastTimestamp 2>&1 | tail -15 | sed 's/^/#   /'; } >&3 || true
+	echo "# ===== END DIAGNOSTICS =====" >&3
+}
+
+# Clean up kubeconfig temp file.
+teardown_file() { rm -f "$FAIL_MARKER" "$KUBECONFIG_FILE"; log "Teardown completed"; }
+
+# ============================================================
+# Test helpers
+# ============================================================
+
+# Poll a mounted secret file until its content matches the expected value.
+# Usage: wait_for_rotation <mount_path> <expected_value> [timeout_seconds]
+wait_for_rotation() {
+	local path="$1" expected="$2" timeout="${3:-60}" elapsed=0
+	while (( elapsed < timeout )); do
+		local actual
+		actual=$(kctl exec "$POD_NAME" -- cat "/mnt/secrets-store/$path" 2>/dev/null) || true
+		if [[ "${actual//$'\r'}" == "$expected" ]]; then return 0; fi
+		sleep 5
+		(( elapsed += 5 ))
+	done
+	log "Timed out waiting for $path to become '$expected' (last: '${actual:-}')"
+	return 1
+}
+
+# Validates that a JSON secret was correctly split into individual key files
+# via jmesPath, and that the corresponding K8s Secret was synced.
+# Called with env vars: USERNAME_ALIAS, USERNAME, PASSWORD_ALIAS, PASSWORD,
+#                       SECRET_FILE_NAME, SECRET_FILE_CONTENT, K8_SECRET_NAME
+validate_jmes_mount() {
+	# Verify individual key files were mounted
+	result=$(kctl exec "$POD_NAME" -- cat "/mnt/secrets-store/$USERNAME_ALIAS")
+	[[ "${result//$'\r'}" == "$USERNAME" ]]
+	result=$(kctl exec "$POD_NAME" -- cat "/mnt/secrets-store/$PASSWORD_ALIAS")
+	[[ "${result//$'\r'}" == "$PASSWORD" ]]
+
+	# Verify the full JSON secret file was also mounted
+	result=$(kctl exec "$POD_NAME" -- cat "/mnt/secrets-store/$SECRET_FILE_NAME")
+	[[ "${result//$'\r'}" == "$SECRET_FILE_CONTENT" ]]
+
+	# Verify the synced K8s Secret contains the extracted values
+	run kctl get secret "$K8_SECRET_NAME"
+	[ "$status" -eq 0 ]
+	result=$(kctl get secret "$K8_SECRET_NAME" -o jsonpath="{.data.username}" | base64 -d)
+	[[ "$result" == "$USERNAME" ]]
+	result=$(kctl get secret "$K8_SECRET_NAME" -o jsonpath="{.data.password}" | base64 -d)
+	[[ "$result" == "$PASSWORD" ]]
+}
+
+# ============================================================
+# Tests: Addon schema validation
+# ============================================================
+
+@test "addon config schema options applied" {
+	if [[ "$INSTALL_METHOD" != "addon" ]]; then skip "Only applies to addon installs"; fi
+	log "Verifying addon config schema options"
+	local addon_ns="aws-secrets-manager" ds="daemonset/aws-secrets-store-csi-driver-provider"
+	dskctl() { kubectl --kubeconfig="$KUBECONFIG_FILE" --namespace "$addon_ns" "$@"; }
+
+	[[ "$(dskctl get "$ds" -o jsonpath='{.spec.template.metadata.labels.integ-test}')" == "true" ]]
+	[[ "$(dskctl get "$ds" -o jsonpath='{.spec.template.metadata.annotations.integ-test-annotation}')" == "true" ]]
+	[[ "$(dskctl get "$ds" -o jsonpath='{.spec.template.spec.containers[0].resources.requests.cpu}')" == "50m" ]]
+	[[ "$(dskctl get "$ds" -o jsonpath='{.spec.template.spec.containers[0].resources.requests.memory}')" == "100Mi" ]]
+	[[ "$(dskctl get "$ds" -o jsonpath='{.spec.template.spec.tolerations[?(@.operator=="Exists")].operator}')" == "Exists" ]]
+	run dskctl get "$ds" -o jsonpath='{.spec.template.spec.containers[0].args}'
+	assert_success
+}
+
+# ============================================================
+# Tests: Provider installation (non-addon only)
+# ============================================================
+
+@test "Install aws provider" {
+	if [[ "$INSTALL_METHOD" == "addon" ]]; then skip "Provider installed via addon"; fi
+	log "Installing AWS provider"
+	# Substitute the placeholder image in the provider YAML with the actual test image
+	local image="${PRIVREPO}${PRIVTAG:+:${PRIVTAG}}" yaml
+	yaml=$(sed "s|\${PRIVREPO}\${PRIVTAG:+:}\${PRIVTAG}|${image}|" "$PROVIDER_YAML")
+	if [[ -n "${GHCR_TOKEN:-}" ]]; then
+		yaml=$(echo "$yaml" | sed '/hostNetwork: false/a\
+      imagePullSecrets:\
+        - name: ghcr-credentials')
+	fi
+	echo "$yaml" | kctl apply -f -
+	kctl wait --for=condition=Ready --timeout="$WAIT_LONG" pod -l app=csi-secrets-store-provider-aws
+	run kctl get pod -l app=csi-secrets-store-provider-aws
+	assert_success
+}
+
+# ============================================================
+# Tests: RBAC and CSI token validation
+# ============================================================
+
+@test "provider does not have serviceaccounts/token create permission" {
+	log "Verifying serviceaccounts/token create permission is absent"
+	local rules
+	rules=$(kctl get clusterrole -l app=csi-secrets-store-provider-aws -o json 2>/dev/null) \
+		|| rules=$(kctl get clusterrole csi-secrets-store-provider-aws-cluster-role -o json)
+	if echo "$rules" | grep -q '"serviceaccounts/token"'; then
+		echo "FAIL: ClusterRole still grants serviceaccounts/token permission" >&3
+		echo "$rules" | grep -A2 'serviceaccounts/token' >&3
+		return 1
+	fi
+}
+
+# ============================================================
+# Tests: SecretProviderClass and pod deployment
+# ============================================================
+
+@test "secretproviderclasses crd is established" {
+	log "Verifying secretproviderclasses CRD"
+	kctl wait --for=condition=established --timeout="$WAIT" crd/secretproviderclasses.secrets-store.csi.x-k8s.io
+	run kctl get crd/secretproviderclasses.secrets-store.csi.x-k8s.io
+	assert_success
+}
+
+@test "deploy aws secretproviderclass crd" {
+	log "Deploying SecretProviderClass"
+	local rendered
+	rendered=$(envsubst < "templates/BasicTestMountSPC.yaml.template")
+	if echo "$rendered" | grep -qE '\$\{[A-Z_]+\}'; then
+		echo "Error: unsubstituted variables in SPC template:" >&3
+		echo "$rendered" | grep -E '\$\{[A-Z_]+\}' >&3
+		return 1
+	fi
+	echo "$rendered" | kctl apply -f -
+	run kctl get secretproviderclasses.secrets-store.csi.x-k8s.io/"basic-test-mount-spc-${ARCH}-${AUTH_TYPE}" -o jsonpath='{.spec.provider}'
+	[[ "$output" == "aws" ]]
+}
+
+@test "CSI inline volume test with pod portability" {
+	log "Deploying test pod"
+	local rendered
+	rendered=$(envsubst < "templates/BasicTestMount.yaml.template")
+	if echo "$rendered" | grep -qE '\$\{[A-Z_]+\}'; then
+		echo "Error: unsubstituted variables in pod template:" >&3
+		echo "$rendered" | grep -E '\$\{[A-Z_]+\}' >&3
+		return 1
+	fi
+	echo "$rendered" | kctl apply -f -
+	kctl wait --for=condition=Ready --timeout="$WAIT_LONG" "pod/$POD_NAME"
+	run kctl get pod/"$POD_NAME"
+	assert_success
+}
+
+# ============================================================
+# Tests: Secret rotation
+# ============================================================
+# These tests verify that the CSI driver's rotation reconciler picks up
+# value changes. The rotation poll interval is set to 15s in the driver config.
+# We poll until the new value appears rather than using a fixed sleep.
+
+@test "CSI inline volume test with rotation - parameter store" {
+	result=$(kctl exec "$POD_NAME" -- cat "/mnt/secrets-store/ParameterStoreRotationTest${P}-${ARCH}-${AUTH_TYPE}")
+	[[ "${result//$'\r'}" == "BeforeRotation" ]]
+	aws ssm put-parameter --name "ParameterStoreRotationTest${P}-${ARCH}-${AUTH_TYPE}" --value AfterRotation --type SecureString --overwrite --region "$REGION"
+	wait_for_rotation "ParameterStoreRotationTest${P}-${ARCH}-${AUTH_TYPE}" "AfterRotation"
+}
+
+@test "CSI inline volume test with rotation - secrets manager" {
+	result=$(kctl exec "$POD_NAME" -- cat "/mnt/secrets-store/SecretsManagerRotationTest${P}-${ARCH}-${AUTH_TYPE}")
+	[[ "${result//$'\r'}" == "BeforeRotation" ]]
+	aws secretsmanager put-secret-value --secret-id "SecretsManagerRotationTest${P}-${ARCH}-${AUTH_TYPE}" --secret-string AfterRotation --region "$REGION"
+	wait_for_rotation "SecretsManagerRotationTest${P}-${ARCH}-${AUTH_TYPE}" "AfterRotation"
+}
+
+# ============================================================
+# Tests: Basic secret/parameter reads
+# ============================================================
+
+@test "read ssm parameters from pod" {
+	result=$(kctl exec "$POD_NAME" -- cat "/mnt/secrets-store/ParameterStoreTest1${P}-${ARCH}-${AUTH_TYPE}")
+	[[ "${result//$'\r'}" == "ParameterStoreTest1Value" ]]
+	# ParameterStoreTest2 uses objectAlias, so the mount path is the alias (no arch-auth suffix)
+	result=$(kctl exec "$POD_NAME" -- cat "/mnt/secrets-store/ParameterStoreTest2${P}")
+	[[ "${result//$'\r'}" == "ParameterStoreTest2Value" ]]
+}
+
+@test "read SecureString SSM parameter from pod" {
+	log "Overwriting parameter as SecureString and verifying read"
+	aws ssm put-parameter --name "ParameterStoreSecureTest${P}-${ARCH}-${AUTH_TYPE}" \
+		--value "SecureStringTestValue" --type SecureString --overwrite --region "$REGION"
+	wait_for_rotation "ParameterStoreSecureTest${P}-${ARCH}-${AUTH_TYPE}" "SecureStringTestValue"
+}
+
+@test "read secrets manager secrets from pod" {
+	result=$(kctl exec "$POD_NAME" -- cat "/mnt/secrets-store/SecretsManagerTest1${P}-${ARCH}-${AUTH_TYPE}")
+	[[ "${result//$'\r'}" == "SecretsManagerTest1Value" ]]
+	# SecretsManagerTest2 uses objectAlias + failoverObject for cross-region failover testing
+	result=$(kctl exec "$POD_NAME" -- cat "/mnt/secrets-store/SecretsManagerTest2${P}")
+	[[ "${result//$'\r'}" == "SecretsManagerTest2Value" ]]
+}
+
+# ============================================================
+# Tests: Cross-region failover
+# ============================================================
+
+@test "failover to secondary region when primary secret is unavailable" {
+	log "Testing cross-region failover for SecretsManagerTest2"
+	# Delete the primary region secret to force failover
+	aws secretsmanager delete-secret --secret-id "SecretsManagerTest2${P}-${ARCH}-${AUTH_TYPE}" \
+		--force-delete-without-recovery --region "$REGION"
+	# Wait for CSI driver rotation to pick up the change and fall back to failover region
+	wait_for_rotation "SecretsManagerTest2${P}" "SecretsManagerTest2Value"
+	# Restore the primary secret and verify it's accessible again
+	aws secretsmanager create-secret --name "SecretsManagerTest2${P}-${ARCH}-${AUTH_TYPE}" \
+		--secret-string "SecretsManagerTest2Value" --region "$REGION" >/dev/null
+	wait_for_rotation "SecretsManagerTest2${P}" "SecretsManagerTest2Value"
+}
+
+# ============================================================
+# Tests: JMES path extraction with rotation
+# ============================================================
+# These tests verify that individual JSON keys can be extracted from a secret
+# and mounted as separate files, and that rotation updates propagate to them.
+
+@test "jmesPath for parameter store with rotation" {
+	JSON_CONTENT='{"username": "ParameterStoreUser", "password": "PasswordForParameterStore"}'
+	USERNAME_ALIAS=ssmUsername USERNAME=ParameterStoreUser PASSWORD_ALIAS=ssmPassword PASSWORD=PasswordForParameterStore \
+	SECRET_FILE_NAME="jsonSsm${P}-${ARCH}-${AUTH_TYPE}" SECRET_FILE_CONTENT="$JSON_CONTENT" K8_SECRET_NAME=json-ssm validate_jmes_mount
+
+	UPDATED_JSON_CONTENT='{"username": "ParameterStoreUserUpdated", "password": "PasswordForParameterStoreUpdated"}'
+	aws ssm put-parameter --name "jsonSsm${P}-${ARCH}-${AUTH_TYPE}" --value "$UPDATED_JSON_CONTENT" --type SecureString --overwrite --region "$REGION"
+	wait_for_rotation "jsonSsm${P}-${ARCH}-${AUTH_TYPE}" "$UPDATED_JSON_CONTENT"
+	USERNAME_ALIAS=ssmUsername USERNAME=ParameterStoreUserUpdated PASSWORD_ALIAS=ssmPassword PASSWORD=PasswordForParameterStoreUpdated \
+	SECRET_FILE_NAME="jsonSsm${P}-${ARCH}-${AUTH_TYPE}" SECRET_FILE_CONTENT="$UPDATED_JSON_CONTENT" K8_SECRET_NAME=json-ssm validate_jmes_mount
+}
+
+@test "jmesPath for secrets manager with rotation" {
+	JSON_CONTENT='{"username": "SecretsManagerUser", "password": "PasswordForSecretsManager"}'
+	USERNAME_ALIAS=secretsManagerUsername USERNAME=SecretsManagerUser PASSWORD_ALIAS=secretsManagerPassword \
+	PASSWORD=PasswordForSecretsManager SECRET_FILE_NAME="secretsManagerJson${P}-${ARCH}-${AUTH_TYPE}" SECRET_FILE_CONTENT="$JSON_CONTENT" \
+	K8_SECRET_NAME=secrets-manager-json validate_jmes_mount
+
+	UPDATED_JSON_CONTENT='{"username": "SecretsManagerUserUpdated", "password": "PasswordForSecretsManagerUpdated"}'
+	aws secretsmanager put-secret-value --secret-id "secretsManagerJson${P}-${ARCH}-${AUTH_TYPE}" --secret-string "$UPDATED_JSON_CONTENT" --region "$REGION"
+	wait_for_rotation "secretsManagerJson${P}-${ARCH}-${AUTH_TYPE}" "$UPDATED_JSON_CONTENT"
+	USERNAME_ALIAS=secretsManagerUsername USERNAME=SecretsManagerUserUpdated PASSWORD_ALIAS=secretsManagerPassword \
+	PASSWORD=PasswordForSecretsManagerUpdated SECRET_FILE_NAME="secretsManagerJson${P}-${ARCH}-${AUTH_TYPE}" SECRET_FILE_CONTENT="$UPDATED_JSON_CONTENT" \
+	K8_SECRET_NAME=secrets-manager-json validate_jmes_mount
+}
+
+# ============================================================
+# Tests: Kubernetes Secret sync
+# ============================================================
+# The CSI driver can sync mounted secrets to native K8s Secrets (configured via
+# secretObjects in the SecretProviderClass). Deleting the pod should also delete
+# the synced Secret.
+
+@test "sync with Kubernetes Secret" {
+	run kctl get secret secret
+	[ "$status" -eq 0 ]
+	result=$(kctl get secret secret -o jsonpath="{.data.username}" | base64 -d)
+	[[ "$result" == "SecretUser" ]]
+}
+
+# ============================================================
+# Tests: Negative / error paths
+# ============================================================
+
+@test "pod with nonexistent secret fails to start" {
+	log "Testing error path: nonexistent secret reference"
+	kctl apply -f - <<-EOF
+	apiVersion: secrets-store.csi.x-k8s.io/v1
+	kind: SecretProviderClass
+	metadata:
+	  name: bad-spc-${ARCH}-${AUTH_TYPE}
+	spec:
+	  provider: aws
+	  parameters:
+	    region: ${REGION}
+	    objects: |
+	      - objectName: "nonexistent-secret-that-does-not-exist"
+	        objectType: "secretsmanager"
+	EOF
+	kctl apply -f - <<-EOF
+	apiVersion: v1
+	kind: Pod
+	metadata:
+	  name: bad-mount-pod-${ARCH}-${AUTH_TYPE}
+	spec:
+	  serviceAccountName: ${SA_NAME}
+	  terminationGracePeriodSeconds: 0
+	  containers:
+	    - image: ${BUSYBOX_IMAGE}
+	      name: busybox
+	      command: ["/bin/sleep", "10000"]
+	      volumeMounts:
+	        - name: secrets-store-inline
+	          mountPath: "/mnt/secrets-store"
+	          readOnly: true
+	  volumes:
+	    - name: secrets-store-inline
+	      csi:
+	        driver: secrets-store.csi.k8s.io
+	        readOnly: true
+	        volumeAttributes:
+	          secretProviderClass: "bad-spc-${ARCH}-${AUTH_TYPE}"
+	EOF
+	# Pod should fail to become Ready because the secret doesn't exist
+	run kctl wait --for=condition=Ready --timeout=60s "pod/bad-mount-pod-${ARCH}-${AUTH_TYPE}"
+	[[ "$status" -ne 0 ]]
+	# Verify the pod has a mount-related error in events
+	run kctl get events --field-selector "involvedObject.name=bad-mount-pod-${ARCH}-${AUTH_TYPE}" -o jsonpath='{.items[*].message}'
+	[[ "$output" == *"FailedMount"* ]] || [[ "$output" == *"failed to mount"* ]] || [[ "$output" == *"rpc error"* ]]
+	# Clean up
+	kctl delete pod "bad-mount-pod-${ARCH}-${AUTH_TYPE}" --force --grace-period=0 2>/dev/null || true
+	kctl delete secretproviderclass "bad-spc-${ARCH}-${AUTH_TYPE}" 2>/dev/null || true
+}
+
+@test "delete pod - synced secret should also be deleted" {
+	run kctl delete pod "$POD_NAME"
+	assert_success
+	kctl wait --for=delete --timeout="$WAIT" secret/secret
+}

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,112 +1,476 @@
 #!/bin/bash
+#
+# Test orchestrator for integration tests.
+#
+# Execution flow:
+#   1. Parse arguments and validate configuration
+#   2. Preflight checks (tools, credentials, stale resources, VPC capacity)
+#   3. Deploy infrastructure for all targets in parallel
+#   4. Run bats tests (single or parallel depending on target count)
+#   5. Dump logs to stdout for CI visibility
+#   6. Tear down infrastructure
+#
+# Usage: ./run-tests.sh [target] [--version <addon-version>]
+#        ./run-tests.sh clean [target]
+#
+set -euo pipefail
 
-cleanup() {
-	cleanup_generated_files
-	cleanup_secrets
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Include vendored tools (bats, kubectl) and Apollo environment binaries in PATH.
+# Harmless when these directories are empty or don't exist.
+export PATH="${PATH}:${SCRIPT_DIR}/tools/bats/bin:${SCRIPT_DIR}/tools:${APOLLO_ENVIRONMENT_ROOT:-}/bin"
+
+# ============================================================
+# Configuration
+# ============================================================
+
+ADDON_VERSION="${ADDON_VERSION:-}"
+INFRA_BACKEND="${INFRA_BACKEND:-auto}"
+INSTALL_METHOD="${INSTALL_METHOD:-auto}"
+RESOURCE_PREFIX="${RESOURCE_PREFIX:-}"
+PIDS=()
+LOG_DIR=""
+DEPLOYED_TARGETS=""
+
+# Timestamped log message to stdout
+ts() { echo "[$(date '+%H:%M:%S')] $*"; }
+
+# Resolve auto backends early so validation can check the actual method
+if [[ "$INFRA_BACKEND" == "auto" ]]; then
+	if command -v eksctl &>/dev/null; then INFRA_BACKEND=eksctl; else INFRA_BACKEND=cfn; fi
+fi
+if [[ "$INSTALL_METHOD" == "auto" ]]; then
+	if [[ -n "${PRIVREPO:-}" ]]; then INSTALL_METHOD=helm; else INSTALL_METHOD=addon; fi
+fi
+
+# Shorthand for calling infra.sh from this script
+infra() { bash "$SCRIPT_DIR/infra.sh" "$@"; }
+
+# ============================================================
+# Process cleanup
+# ============================================================
+
+# Kill background jobs and clean up infrastructure on exit.
+on_exit() {
+	local exit_code=$?
+	# Kill any background jobs (parallel deploys or test runs) on exit
+	local pids
+	pids=$(jobs -p 2>/dev/null) || true
+	if [[ -n "$pids" ]]; then
+		kill $pids 2>/dev/null || true
+		wait 2>/dev/null || true
+	fi
+	# Clean up deployed infrastructure if the script was interrupted
+	if [[ -n "$DEPLOYED_TARGETS" ]]; then
+		echo ""
+		ts "Cleaning up infrastructure for: $DEPLOYED_TARGETS"
+		for t in $DEPLOYED_TARGETS; do
+			infra delete "$t" 2>/dev/null &
+		done
+		wait 2>/dev/null || true
+	fi
+	if [[ -n "${LOG_DIR:-}" && -d "${LOG_DIR:-}" ]]; then
+		echo ""
+		echo "Test logs: $LOG_DIR"
+	fi
+	exit $exit_code
+}
+trap 'on_exit' EXIT
+trap 'exit 130' INT TERM
+
+# ============================================================
+# Region detection
+# ============================================================
+
+# Populate REGION and FAILOVERREGION by delegating to infra.sh.
+detect_regions() {
+	if [[ -n "${REGION:-}" && -n "${FAILOVERREGION:-}" ]]; then return; fi
+	eval "$(infra print-regions)"
+	export REGION FAILOVERREGION
 }
 
-check_parallel() {
-	if ! command -v parallel >/dev/null 2>&1; then
-		echo "GNU parallel not found. Please install: \`brew install parallel\`"
+# ============================================================
+# Target resolution
+# ============================================================
+# Targets are arch-auth combinations: x64-irsa, x64-pod-identity, arm-irsa, arm-pod-identity.
+# Shorthand names expand to multiple targets for convenience.
+
+# Expand a target shorthand (e.g. "x64") into individual arch-auth combinations.
+resolve_targets() {
+	case "$1" in
+		""|all)           echo "x64-irsa x64-pod-identity arm-irsa arm-pod-identity" ;;
+		x64)              echo "x64-irsa x64-pod-identity" ;;
+		arm)              echo "arm-irsa arm-pod-identity" ;;
+		irsa)             echo "x64-irsa arm-irsa" ;;
+		pod-identity)     echo "x64-pod-identity arm-pod-identity" ;;
+		x64-irsa|x64-pod-identity|arm-irsa|arm-pod-identity) echo "$1" ;;
+		*) echo "Error: Unknown target '$1'" >&2; exit 1 ;;
+	esac
+}
+
+# ============================================================
+# Preflight checks
+# ============================================================
+
+# Verify tools, credentials, stale resources, and VPC capacity before testing.
+preflight() {
+	local region="$1"; shift; local targets=("$@")
+	ts "=== Preflight checks ==="
+
+	# --- Required tools (varies by backend and install method) ---
+	local missing=()
+	for tool in aws kubectl bats envsubst; do
+		if ! command -v "$tool" >/dev/null 2>&1; then missing+=("$tool"); fi
+	done
+	if [[ "$INFRA_BACKEND" == "eksctl" ]]; then
+		if ! command -v eksctl >/dev/null 2>&1; then missing+=("eksctl"); fi
+	fi
+	if [[ "$INSTALL_METHOD" == "helm" ]]; then
+		if ! command -v helm >/dev/null 2>&1; then missing+=("helm"); fi
+	fi
+	if [[ ${#missing[@]} -gt 0 ]]; then
+		echo "Error: Missing tools: ${missing[*]}"; exit 1
+	fi
+
+	# --- AWS credentials + optional account allowlist ---
+	# ALLOWED_ACCOUNTS_FILE is an external file (one account ID per line, # comments allowed)
+	# that restricts which AWS accounts can run these tests. Used in restricted environments
+	# to prevent accidental runs against production accounts. Not set by default.
+	local account
+	account=$(aws sts get-caller-identity --query Account --output text 2>/dev/null) || {
+		echo "Error: AWS credentials not configured"; exit 1
+	}
+	if [[ -n "${ALLOWED_ACCOUNTS_FILE:-}" && -f "${ALLOWED_ACCOUNTS_FILE:-}" ]]; then
+		if ! grep -qxF "$account" <(sed 's/#.*//;s/ //g;/^$/d' "$ALLOWED_ACCOUNTS_FILE"); then
+			echo "Error: Account $account not in allowlist ($ALLOWED_ACCOUNTS_FILE)"; exit 1
+		fi
+	fi
+
+	# --- Clean up stale resources from previous runs ---
+	infra cleanup-stale "${targets[@]}"
+
+	# --- Detect concurrent test runs ---
+	local other_stacks
+	other_stacks=$(aws cloudformation list-stacks --region "$region" \
+		--query "StackSummaries[?starts_with(StackName,'integ-cluster-') && StackStatus!='DELETE_COMPLETE' && StackStatus!='DELETE_IN_PROGRESS'].[StackName]" \
+		--output text 2>/dev/null) || true
+	if [[ -n "$other_stacks" ]]; then
+		# Filter out stacks that belong to our target set (those are handled by cleanup-stale)
+		local foreign=""
+		for s in $other_stacks; do
+			local is_ours=false
+			for t in "${targets[@]}"; do
+				if [[ "$s" == "integ-cluster-${t}" ]]; then is_ours=true; break; fi
+			done
+			if [[ "$is_ours" == "false" ]]; then foreign+=" $s"; fi
+		done
+		if [[ -n "$foreign" ]]; then
+			echo "⚠ Warning: Found integ-cluster stacks from another run:$foreign"
+			echo "  Another test run may be in progress. Use RESOURCE_PREFIX to avoid collisions."
+		fi
+	fi
+
+	# --- Warn if failover region equals primary ---
+	if [[ "$REGION" == "$FAILOVERREGION" ]]; then
+		echo "⚠ Warning: FAILOVERREGION ($FAILOVERREGION) equals REGION — failover tests will not exercise cross-region behavior"
+	fi
+
+	# --- VPC capacity (each test target creates one VPC) ---
+	local vpc_limit vpc_count available needed=${#targets[@]}
+	vpc_limit=$(aws service-quotas get-service-quota --service-code vpc --quota-code L-F678F1CE \
+		--query 'Quota.Value' --output text --region "$region" 2>/dev/null) || vpc_limit=5
+	vpc_count=$(aws ec2 describe-vpcs --region "$region" --query 'length(Vpcs)' --output text)
+	available=$((${vpc_limit%.*} - vpc_count))
+	echo "VPC capacity: ${vpc_count}/${vpc_limit%.*} used, ${available} available, ${needed} needed"
+	if [[ $available -lt $needed ]]; then
+		echo "Error: Not enough VPC capacity"; exit 1
+	fi
+
+	ts "=== Preflight passed ==="
+	echo ""
+}
+
+# ============================================================
+# Infrastructure deployment (parallel)
+# ============================================================
+
+# Deploy infrastructure for all targets in parallel; exit on any failure.
+# Each deploy writes to its own log file to avoid interleaved output.
+deploy_all() {
+	local deploy_pids=() failed=0
+	for t in "$@"; do
+		infra deploy "$t" >"${LOG_DIR}/deploy-${t}.log" 2>&1 &
+		deploy_pids+=("$!:$t")
+	done
+	for entry in "${deploy_pids[@]}"; do
+		if ! wait "${entry%%:*}"; then
+			ts "✗ Deploy failed for ${entry#*:}"; failed=1
+		else
+			ts "✓ Deploy succeeded for ${entry#*:}"
+		fi
+	done
+	if [[ $failed -eq 1 ]]; then
+		echo "Error: Deployment failed. Deploy logs:"
+		for t in "$@"; do
+			local lf="${LOG_DIR}/deploy-${t}.log"
+			if [[ -f "$lf" ]]; then echo "--- deploy: ${t} ---"; cat "$lf"; fi
+		done
+		echo "Cleaning up..."
+		for t in "$@"; do infra delete "$t" 2>/dev/null || true; done
 		exit 1
 	fi
 }
 
-generate_test_files() {
-	echo "Generating test files from templates..."
-	if [[ ! -f "generate-test-files.py" ]]; then
-		echo "Error: generate-test-files.py not found!"
-		exit 1
-	fi
+# ============================================================
+# Test execution
+# ============================================================
 
-	python3 generate-test-files.py
-	if [[ $? -ne 0 ]]; then
-		echo "Error: Failed to generate test files from templates"
-		exit 1
+# Run bats for a single arch+auth target. All configuration is passed via
+# environment variables so bats doesn't need to know about run-tests.sh internals.
+run_test() {
+	local arch=$1 auth_type=$2 label="${1}-${2}" parallel="${3:-false}"
+	detect_regions
+	local log_file="${LOG_DIR}/${label}.log"
+	ts "Starting ${label} tests (log: ${log_file})..."
+
+	local env_args=(
+		ARCH="$arch" AUTH_TYPE="$auth_type" REGION="$REGION" FAILOVERREGION="$FAILOVERREGION"
+		INFRA_BACKEND="$INFRA_BACKEND" INSTALL_METHOD="$INSTALL_METHOD"
+		RESOURCE_PREFIX="$RESOURCE_PREFIX" ADDON_VERSION="$ADDON_VERSION"
+		POD_IDENTITY_ROLE_ARN="${POD_IDENTITY_ROLE_ARN:-}"
+		PRIVREPO="${PRIVREPO:-}" PRIVTAG="${PRIVTAG:-}" GHCR_TOKEN="${GHCR_TOKEN:-}"
+		PROVIDER_YAML="${PROVIDER_YAML:-}" EKS_VERSION="${EKS_VERSION:-}"
+	)
+
+	if [[ "$parallel" == "true" ]]; then
+		env "${env_args[@]}" bats ${BATS_FILTER:+--filter "$BATS_FILTER"} integration.bats >"$log_file" 2>&1 3>&1
+		local rc=$?
+		if [[ $rc -eq 0 ]]; then
+			ts "✓ ${label} passed"
+		else
+			ts "✗ ${label} FAILED (see ${log_file})"
+		fi
+		return $rc
+	else
+		env "${env_args[@]}" bats ${BATS_FILTER:+--filter "$BATS_FILTER"} integration.bats 2>&1 | tee "$log_file"
+		return "${PIPESTATUS[0]}"
 	fi
-	echo "Test files generated successfully"
 }
 
-cleanup_generated_files() {
-	echo "Cleaning up generated test files..."
-	rm -f x64-irsa.bats x64-pod-identity.bats arm-irsa.bats arm-pod-identity.bats
-	rm -f BasicTestMountSPC-x64-irsa.yaml BasicTestMountSPC-x64-pod-identity.yaml BasicTestMountSPC-arm-irsa.yaml BasicTestMountSPC-arm-pod-identity.yaml
-	rm -f BasicTestMount-x64-irsa.yaml BasicTestMount-x64-pod-identity.yaml BasicTestMount-arm-irsa.yaml BasicTestMount-arm-pod-identity.yaml
-	echo "Generated test files cleaned up"
+# Run bats tests for multiple targets in parallel; return non-zero if any fail.
+run_parallel() {
+	local -A pid_target
+	for target in "$@"; do
+		run_test "${target%%-*}" "${target#*-}" true &
+		pid_target[$!]="$target"
+		PIDS+=($!)
+	done
+	FAILED_TARGETS=0
+	for pid in "${PIDS[@]}"; do
+		if ! wait "$pid"; then ((FAILED_TARGETS++)); fi
+	done
+	return $(( FAILED_TARGETS > 0 ? 1 : 0 ))
 }
 
-delete_cluster() {
-	eksctl delete cluster --name $1 --parallel 25
-}
+# ============================================================
+# Argument parsing
+# ============================================================
 
-cleanup_secrets() {
-	echo "Cleaning up secrets and parameters..."
-	python3 generate-test-files.py cleanup-secrets
-}
+TEST_TARGET=""
+CLEAN_TARGETS=""
+SKIP_DEPLOY=false
+SKIP_CLEANUP=false
+BATS_FILTER=""
+if [[ $# -gt 0 && "$1" == "clean" ]]; then
+	TEST_TARGET="clean"; shift
+	if [[ $# -gt 0 && "$1" != "--"* ]]; then CLEAN_TARGETS="$1"; shift; fi
+elif [[ $# -gt 0 && "$1" != "--"* ]]; then
+	TEST_TARGET="$1"; shift
+fi
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--version) ADDON_VERSION="$2"; shift 2 ;;
+		--skip-deploy) SKIP_DEPLOY=true; shift ;;
+		--skip-cleanup) SKIP_CLEANUP=true; shift ;;
+		--filter) BATS_FILTER="$2"; shift 2 ;;
+		*) echo "Error: Unknown argument '$1'"; exit 1 ;;
+	esac
+done
 
-if [[ "$1" == "clean" ]]; then
-	cleanup
+# ============================================================
+# Validation
+# ============================================================
 
-	if [[ "$2" == "all" || "$2" == "x64" || "$2" == "pod-identity" || "$2" == "x64-pod-identity" ]]; then
-		delete_cluster integ-cluster-x64-pod-identity
+if [[ "$TEST_TARGET" != "clean" ]]; then
+	if [[ "$(resolve_targets "${TEST_TARGET:-}")" == *"pod-identity"* && -z "${POD_IDENTITY_ROLE_ARN:-}" ]]; then
+		echo "Error: POD_IDENTITY_ROLE_ARN required for pod-identity tests"; exit 1
 	fi
-	if [[ "$2" == "all" || "$2" == "x64" || "$2" == "irsa" || "$2" == "x64-irsa" ]]; then
-		delete_cluster integ-cluster-x64-irsa
+	if [[ "$INSTALL_METHOD" == "helm" || "$INSTALL_METHOD" == "yaml" ]]; then
+		if [[ -z "${PRIVREPO:-}" ]]; then
+			echo "Error: PRIVREPO required for $INSTALL_METHOD install"; exit 1
+		fi
+		provider_yaml="${PROVIDER_YAML:-../deployment/private-installer.yaml}"
+		if [[ ! -f "$provider_yaml" ]]; then
+			echo "Error: PROVIDER_YAML not found at $provider_yaml"; exit 1
+		fi
+		# Validate that the image exists in ECR (only for ECR repos, not ghcr.io etc.)
+		if [[ "$PRIVREPO" == *".dkr.ecr."*".amazonaws.com/"* ]]; then
+			ecr_region=$(echo "$PRIVREPO" | sed 's/.*\.dkr\.ecr\.\(.*\)\.amazonaws\.com.*/\1/')
+			ecr_repo=$(echo "$PRIVREPO" | sed 's/.*\.amazonaws\.com\///')
+			ecr_tag="${PRIVTAG:-latest}"
+			echo "Validating ECR image: ${PRIVREPO}:${ecr_tag}..."
+			if ! aws ecr describe-images --repository-name "$ecr_repo" --image-ids "imageTag=$ecr_tag" \
+				--region "$ecr_region" --query 'imageDetails[0].imageDigest' --output text >/dev/null 2>&1; then
+				echo "Error: Image not found in ECR: ${PRIVREPO}:${ecr_tag}"; exit 1
+			fi
+			echo "✓ ECR image validated"
+		fi
 	fi
-	if [[ "$2" == "all" || "$2" == "arm" || "$2" == "pod-identity" || "$2" == "arm-pod-identity" ]]; then
-		delete_cluster integ-cluster-arm-pod-identity
+fi
+
+# ============================================================
+# Main execution
+# ============================================================
+
+cd "$SCRIPT_DIR"
+
+# --- Clean mode: tear down and exit ---
+# Detects how each cluster was created (cfn vs eksctl) by checking for the
+# presence of eksctl-managed CFN stacks, rather than relying on INFRA_BACKEND.
+if [[ "$TEST_TARGET" == "clean" ]]; then
+	detect_regions
+	local_targets=$(resolve_targets "${CLEAN_TARGETS:-all}")
+	clean_dir=$(mktemp -d)
+	ts "=== Cleaning up: $local_targets ==="
+	for t in $local_targets; do
+		(
+			cluster="integ-cluster-${t}"
+			# Check if this cluster was created by eksctl (eksctl-prefixed CFN stacks exist)
+			eksctl_stack=$(aws cloudformation describe-stacks --stack-name "eksctl-${cluster}-cluster" \
+				--region "$REGION" --query 'Stacks[0].StackStatus' --output text 2>/dev/null) || eksctl_stack=""
+			if [[ -n "$eksctl_stack" ]]; then
+				INFRA_BACKEND=eksctl
+			else
+				INFRA_BACKEND=cfn
+			fi
+			export INFRA_BACKEND
+			bash "$SCRIPT_DIR/infra.sh" delete "$t"
+		) >"${clean_dir}/${t}.log" 2>&1 &
+	done
+	wait
+	for t in $local_targets; do
+		echo ""
+		echo "--- clean: ${t} ---"
+		cat "${clean_dir}/${t}.log"
+	done
+	rm -rf "$clean_dir"
+	echo ""
+	ts "=== Cleanup complete ==="
+	exit 0
+fi
+
+# --- Normal mode: preflight → deploy → test → results → cleanup ---
+detect_regions
+targets=$(resolve_targets "${TEST_TARGET:-all}")
+
+echo "=== Test Configuration ==="
+echo "  Region: $REGION | Failover: $FAILOVERREGION"
+echo "  Targets: $targets"
+echo "  Backend: $INFRA_BACKEND | Install: $INSTALL_METHOD | Prefix: ${RESOURCE_PREFIX:-(none)}"
+if [[ "$INSTALL_METHOD" == "helm" || "$INSTALL_METHOD" == "yaml" ]]; then
+	echo "  Provider image: ${PRIVREPO:-}${PRIVTAG:+:${PRIVTAG}}"
+	echo "  Provider YAML: ${PROVIDER_YAML:-../deployment/private-installer.yaml}"
+	driver_version=$(helm search repo secrets-store-csi-driver/secrets-store-csi-driver --output json 2>/dev/null \
+		| grep -o '"version":"[^"]*"' | head -1 | cut -d'"' -f4) || true
+	if [[ -n "${driver_version:-}" ]]; then
+		echo "  CSI driver version: $driver_version (helm)"
 	fi
-	if [[ "$2" == "all" || "$2" == "arm" || "$2" == "irsa" || "$2" == "arm-irsa" ]]; then
-		delete_cluster integ-cluster-arm-irsa
+fi
+if [[ "$INSTALL_METHOD" == "addon" && -n "${ADDON_VERSION:-}" ]]; then
+	echo "  Addon version: $ADDON_VERSION"
+fi
+echo ""
+
+# shellcheck disable=SC2086
+preflight "$REGION" $targets
+
+LOG_DIR="logs/$(date +'%Y-%m-%d_%H-%M-%S')"; mkdir -p "$LOG_DIR"
+
+if [[ "$SKIP_DEPLOY" == "true" ]]; then
+	ts "Skipping deploy (--skip-deploy)"
+else
+	# shellcheck disable=SC2086
+	deploy_all $targets
+fi
+DEPLOYED_TARGETS="$targets"
+
+target_count=$(echo "$targets" | wc -w | tr -d ' ')
+
+# Run tests. The || rc=$? prevents set -e from exiting before cleanup runs.
+rc=0
+FAILED_TARGETS=0
+if [[ $target_count -eq 1 ]]; then
+	run_test "${targets%%-*}" "${targets#*-}" || { rc=$?; FAILED_TARGETS=1; }
+else
+	# shellcheck disable=SC2086
+	run_parallel $targets || rc=$?
+fi
+
+# Dump full logs to stdout so CI systems capture them in build output
+echo ""
+echo "=== Deploy Logs ==="
+for f in "$LOG_DIR"/deploy-*.log; do
+	if [[ -f "$f" ]]; then
+		echo ""
+		echo "--- $(basename "$f") ---"
+		cat "$f"
 	fi
+done
 
-	exit $?
-fi
+echo ""
+echo "=== Test Logs ==="
+for t in $targets; do
+	f="$LOG_DIR/${t}.log"
+	if [[ -f "$f" ]]; then
+		echo ""
+		echo "--- $(basename "$f") ---"
+		cat "$f"
+	fi
+done
 
-# Generate test files from templates (this also creates secrets)
-generate_test_files
-
-# Run tests based on argument
-if [[ "$1" == "all" || "$1" == "" ]]; then
-	check_parallel
-	echo "Running all tests: x64-irsa, x64-pod-identity, arm-irsa, arm-pod-identity"
-	bats --jobs 4 --no-parallelize-within-files x64-irsa.bats x64-pod-identity.bats arm-irsa.bats arm-pod-identity.bats
-fi
-if [[ "$1" == "irsa" ]]; then
-	check_parallel
-	echo "Running IRSA tests: x64-irsa, arm-irsa"
-	bats --jobs 2 --no-parallelize-within-files x64-irsa.bats arm-irsa.bats
-fi
-if [[ "$1" == "pod-identity" ]]; then
-	check_parallel
-	echo "Running Pod Identity tests: x64-pod-identity, arm-pod-identity"
-	bats --jobs 2 --no-parallelize-within-files x64-pod-identity.bats arm-pod-identity.bats
-fi
-if [[ "$1" == "x64" ]]; then
-	check_parallel
-	echo "Running x64 tests: x64-irsa, x64-pod-identity"
-	bats --jobs 2 --no-parallelize-within-files x64-irsa.bats x64-pod-identity.bats
-fi
-if [[ "$1" == "arm" ]]; then
-	check_parallel
-	echo "Running ARM tests: arm-irsa, arm-pod-identity"
-	bats --jobs 2 --no-parallelize-within-files arm-irsa.bats arm-pod-identity.bats
-fi
-if [[ "$1" == "x64-irsa" ]]; then
-	echo "Running x64 IRSA test: x64-irsa"
-	bats x64-irsa.bats
-fi
-if [[ "$1" == "x64-pod-identity" ]]; then
-	echo "Running x64 Pod Identity test: x64-pod-identity"
-	bats x64-pod-identity.bats
-fi
-if [[ "$1" == "arm-irsa" ]]; then
-	echo "Running ARM IRSA test: arm-irsa"
-	bats arm-irsa.bats
-fi
-if [[ "$1" == "arm-pod-identity" ]]; then
-	echo "Running ARM Pod Identity test: arm-pod-identity"
-	bats arm-pod-identity.bats
+echo ""
+if [[ "$SKIP_CLEANUP" == "true" ]]; then
+	ts "Skipping cleanup (--skip-cleanup)"
+	DEPLOYED_TARGETS=""
+else
+	echo "=== Cleanup ==="
+	cleanup_pids=()
+	for t in $targets; do
+		infra delete "$t" >"${LOG_DIR}/cleanup-${t}.log" 2>&1 &
+		cleanup_pids+=("$!:$t")
+	done
+	for entry in "${cleanup_pids[@]}"; do
+		if ! wait "${entry%%:*}"; then
+			ts "✗ Cleanup failed for ${entry#*:}"
+		else
+			ts "✓ Cleanup succeeded for ${entry#*:}"
+		fi
+	done
+	DEPLOYED_TARGETS=""
+	for t in $targets; do
+		if [[ -f "${LOG_DIR}/cleanup-${t}.log" ]]; then
+			echo "--- cleanup: ${t} ---"
+			cat "${LOG_DIR}/cleanup-${t}.log"
+		fi
+	done
 fi
 
-cleanup
+# Final summary
+echo ""
+if [[ $rc -eq 0 ]]; then
+	ts "=== ${target_count} of ${target_count} targets passed ==="
+else
+	passed=$(( target_count - FAILED_TARGETS ))
+	ts "=== ${passed} of ${target_count} targets passed ==="
+fi
+exit $rc


### PR DESCRIPTION
## Issue #, if available:

N/A — part of test framework migration (depends on [#580](https://github.com/aws/secrets-store-csi-driver-provider-aws/pull/580)).

## Description of changes:

Replace run-tests.sh, helpers.bash, and README.md with unified framework versions, and add the new integration.bats test file.

Replaced files:
- `tests/run-tests.sh` — Full orchestrator with preflight checks (tools, credentials, VPC capacity, concurrent run detection, FAILOVERREGION==REGION warning), parallel infrastructure deployment, log management, and pluggable backends. New flags: `--skip-deploy`, `--skip-cleanup`, `--filter <regex>`.
- `tests/helpers.bash` — Simplified to assert_success, assert_failure, assert_output_contains.
- `tests/README.md` — Comprehensive docs covering architecture, backends, install methods, env vars, flags, and file structure.

New file:
- `tests/integration.bats` — Single test file covering: addon schema validation, provider install, RBAC verification, SecretProviderClass deployment, pod mount, SSM parameter reads, SecureString reads, Secrets Manager reads, cross-region failover, secret rotation (SSM + SM), JMES path extraction with rotation, K8s Secret sync, negative test (nonexistent secret), and pod deletion cleanup.

Key improvements over the old system:
- No python3/boto3 dependency — secrets managed via CloudFormation
- Pluggable infra backends (cfn/eksctl) and install methods (addon/helm/yaml)
- Fail-fast per target with diagnostics dump
- Deploy failure logs printed immediately
- Exit code-based failure counting (not log file grepping)
- TTL tags on CFN stacks for orphan cleanup

PR chain: [#579](https://github.com/aws/secrets-store-csi-driver-provider-aws/pull/579) Add infrastructure files → [#580](https://github.com/aws/secrets-store-csi-driver-provider-aws/pull/580) Delete old files → **3/4** → [#582](https://github.com/aws/secrets-store-csi-driver-provider-aws/pull/582) Update CI workflow

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.