### PR TITLE
chore: update GitHub Actions workflow for unified test framework [4/4]

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -57,6 +57,7 @@ jobs:
       - name: List images
         run: |
           docker image ls -a
+
   integration-tests:
     name: Run Integration Tests
     needs: build-docker
@@ -103,14 +104,6 @@ jobs:
 
       - run: eksctl version
 
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3"
-
-      - name: Install Python dependencies
-        run: pip install boto3
-
       - name: Setup Bats and bats libs
         id: setup-bats
         uses: bats-core/bats-action@3.0.1
@@ -134,6 +127,7 @@ jobs:
           POD_IDENTITY_ROLE_ARN: ${{ secrets.POD_IDENTITY_ROLE_ARN }}
           PRIVREPO: ghcr.io/${{ github.repository_owner }}/test-build
           PRIVTAG: latest-${{ matrix.arch }}-${{ github.run_id }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REGION: us-west-2
           FAILOVERREGION: us-east-2
 


### PR DESCRIPTION
## Issue #, if available:

N/A — part of test framework migration (depends on [#581](https://github.com/aws/secrets-store-csi-driver-provider-aws/pull/581)).

## Description of changes:

Update `.github/workflows/integ.yml` to work with the new unified test framework.

Changes:
- Remove `Setup Python` step — no longer needed (secrets managed via CloudFormation, not boto3)
- Remove `Install Python dependencies` step — no longer needed
- Add `GHCR_TOKEN` env var to the test step — used by integration.bats to create an image pull secret in the test cluster for pulling the GHCR-hosted test image

The run-tests.sh CLI interface is unchanged (`./run-tests.sh <target>` and `./run-tests.sh clean <target>`), so the workflow invocation and cleanup step remain the same.

PR chain: [#579](https://github.com/aws/secrets-store-csi-driver-provider-aws/pull/579) Add infrastructure files → [#580](https://github.com/aws/secrets-store-csi-driver-provider-aws/pull/580) Delete old files → [#581](https://github.com/aws/secrets-store-csi-driver-provider-aws/pull/581) Add new orchestrator + tests → **4/4**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.