### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/aws/secrets-store-csi-driver-provider-aws/security/code-scanning/2](https://github.com/aws/secrets-store-csi-driver-provider-aws/security/code-scanning/2)

In general, this problem is fixed by explicitly defining a `permissions` block at the workflow root or per job, granting only the scopes required. For this workflow, it only needs to read repository contents (for `actions/checkout`); Docker operations are local and do not require GitHub token scopes. Thus, the minimal and appropriate configuration is `permissions: contents: read`.

The best fix here is to add a root-level `permissions` block right after the `on:` section (or before `jobs:`) in `.github/workflows/docker-image.yml`. This block will apply to all jobs (there is only `build`), without changing the workflow’s functional behavior. Concretely, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block (lines 3–7) and the `jobs:` block (line 9). No additional imports or definitions are needed; this is pure workflow configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
