### PR TITLE
fix: Prevent scheduling `secrets-store-csi-driver` on Fargate

### DIFF
--- a/charts/secrets-store-csi-driver-provider-aws/values.yaml
+++ b/charts/secrets-store-csi-driver-provider-aws/values.yaml
@@ -64,3 +64,18 @@ secrets-store-csi-driver:
   tokenRequests:
     - audience: "sts.amazonaws.com"
     - audience: "pods.eks.amazonaws.com"
+
+  linux:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: type
+                  operator: NotIn
+                  values:
+                    - virtual-kubelet
+                - key: eks.amazonaws.com/compute-type
+                  operator: NotIn
+                  values:
+                    - fargate


### PR DESCRIPTION
## Description

The PR adds (as was suggested in the ticket) the override for `linux.affinity`, including the [default value of the secret-store-csi-driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blame/main/charts/secrets-store-csi-driver/values.yaml#L27-L36)). The selector term prevents scheduling `secrets-store-csi-driver` DS pods to the `eks.amazonaws.com/compute-type: fargate`.

### Why is this change being made?

Currently when `secrets-store-csi-driver-provider-aws` is deployed as an EKS Add-on the `secrets-store-csi-driver` DS also tries to schedule pods on the Fargate nodes due to missing `nodeAffinity` selector term.

### What is changing?

Added `linux.affinity` to the `secrets-store-csi-driver` dependency in `charts/secrets-store-csi-driver-provider-aws/values.yaml`

### Related Links
- #586 

---

## Testing

### How was this tested?

Vetted locally rendering the K8s manifests from the Helm chart
```sh
helm template \
  secrets-store-csi-driver-provider-aws \
  aws-secrets-manager/secrets-store-csi-driver-provider-aws \
  -f charts/secrets-store-csi-driver-provider-aws/values.yaml \
  --output-dir ~/TMP/helm_rendered
```

### When testing locally, provide testing artifact(s):

The diff shows presence of the required `nodeSelectorTerm`

```diff
diff --git a/helm_rendered/secrets-store-csi-driver-provider-aws/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml b/helm_rendered/secrets-store-csi-driver-provider-aws/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
index b890f16..07f728a 100644
--- a/helm_rendered/secrets-store-csi-driver-provider-aws/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
+++ b/helm_rendered/secrets-store-csi-driver-provider-aws/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
@@ -43,6 +43,10 @@ spec:
                 operator: NotIn
                 values:
                 - virtual-kubelet
+              - key: eks.amazonaws.com/compute-type
+                operator: NotIn
+                values:
+                - fargate
       containers:
         - name: node-driver-registrar
           image: "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0"
```

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
  *If not, why:*
- [x] I have filled out the Description and Testing sections above
  *If not, why:*
- [ ] Build and Unit tests are passing
  *If not, why:*
- [ ] Unit test coverage check is passing
  *If not, why:*
- [ ] Integration tests pass locally
  *If not, why:*
- [ ] I have updated integration tests (if needed)
  *If not, why:*
- [x] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:*
- [x] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:*
- [ ] I have updated README/documentation (if needed)
  *If not, why:*
- [ ] I have clearly called out breaking changes (if any)
  *If not, why:*

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
