### PR TITLE
Fail helm release if Chart.lock is out of date.

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -44,6 +44,15 @@ jobs:
       - name: Add SSCD Helm Repo
         run: helm repo add secrets-store-csi-driver https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts
 
+      - name: Check dependency lock is up to date
+        run: |
+          helm dependency update charts/secrets-store-csi-driver-provider-aws
+          if ! git diff --quiet charts/secrets-store-csi-driver-provider-aws/Chart.lock; then
+            echo "::error::Chart.lock is out of date. Run 'helm dependency update' and commit the changes before releasing."
+            git diff charts/secrets-store-csi-driver-provider-aws/Chart.lock
+            exit 1
+          fi
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         with:


### PR DESCRIPTION
## Description

### Why is this change being made?

1. This ensures that we don't inadvertently perform a release without updating Chart.lock to the latest major version of the driver.


### What is changing?

1. Added a GH action workflow step to perform a git diff


### Related Links
- **Issue #, if available**:

---

## Testing

### How was this tested?

1. Tested the command in CLI by resetting the chart.lock back to an older version and ensuring that I do get a git diff out of running `helm dependency update`.

### When testing locally, provide testing artifact(s):

1. 

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
  *If not, why:*
- [x] I have filled out the Description and Testing sections above
  *If not, why:*
- [x] Build and Unit tests are passing
  *If not, why:*
- [x] Unit test coverage check is passing
  *If not, why:*
- [x] Integration tests pass locally
  *If not, why:*
- [ ] I have updated integration tests (if needed)
  *If not, why:* No changes needed
- [x] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:*
- [x] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:*
- [ ] I have updated README/documentation (if needed)
  *If not, why:* No doc changes
- [ ] I have clearly called out breaking changes (if any)
  *If not, why:* No breaking changes

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
