### PR TITLE
fix(ci): JMESPath test cases

### DIFF
--- a/tests/integration.bats.template
+++ b/tests/integration.bats.template
@@ -263,6 +263,11 @@ validate_jmes_mount() {
 	log "Validating Parameter Store JMES path rotation"
 	cmd="kubectl --kubeconfig=${{KUBECONFIG_VAR}} --namespace $NAMESPACE exec $POD_NAME -- cat /mnt/secrets-store/ssmUsername | tr -d '\\r' | grep -qx ParameterStoreUserUpdated"
 	wait_for_process 240 5 "$cmd"
+	# The synced K8s Secret is reconciled by the CSI driver after the mount write
+	# completes, so the secret object lags behind the mount on slower clusters.
+	# Wait for the synced K8s Secret to reflect the rotated value before asserting.
+	cmd="[[ \"\$(kubectl --kubeconfig=${{KUBECONFIG_VAR}} --namespace=$NAMESPACE get secret json-ssm -o jsonpath='{.data.username}' | base64 -d | tr -d '\\r')\" == ParameterStoreUserUpdated ]]"
+	wait_for_process 240 5 "$cmd"
 	USERNAME_ALIAS=ssmUsername USERNAME=ParameterStoreUserUpdated PASSWORD_ALIAS=ssmPassword PASSWORD=PasswordForParameterStoreUpdated\
 	SECRET_FILE_NAME=jsonSsm-{{ARCH}}-{{AUTH_TYPE}} SECRET_FILE_CONTENT=$UPDATED_JSON_CONTENT K8_SECRET_NAME=json-ssm validate_jmes_mount
 
@@ -287,6 +292,11 @@ validate_jmes_mount() {
 	# Poll for the rotated username to land in the mount before re-validating.
 	log "Validating Secrets Manager JMES path rotation"
 	cmd="kubectl --kubeconfig=${{KUBECONFIG_VAR}} --namespace $NAMESPACE exec $POD_NAME -- cat /mnt/secrets-store/secretsManagerUsername | tr -d '\\r' | grep -qx SecretsManagerUserUpdated"
+	wait_for_process 240 5 "$cmd"
+	# The synced K8s Secret is reconciled by the CSI driver after the mount write
+	# completes, so the secret object lags behind the mount on slower clusters.
+	# Wait for the synced K8s Secret to reflect the rotated value before asserting.
+	cmd="[[ \"\$(kubectl --kubeconfig=${{KUBECONFIG_VAR}} --namespace=$NAMESPACE get secret secrets-manager-json -o jsonpath='{.data.username}' | base64 -d | tr -d '\\r')\" == SecretsManagerUserUpdated ]]"
 	wait_for_process 240 5 "$cmd"
 	USERNAME_ALIAS=secretsManagerUsername USERNAME=SecretsManagerUserUpdated PASSWORD_ALIAS=secretsManagerPassword \
 	PASSWORD=PasswordForSecretsManagerUpdated SECRET_FILE_NAME=secretsManagerJson-{{ARCH}}-{{AUTH_TYPE}} SECRET_FILE_CONTENT=$UPDATED_JSON_CONTENT


### PR DESCRIPTION
## Description

### Why is this change being made?

1. The two JMES path rotation integration tests were still failing after the v1.6.0 driver upgrade in #612, even though they pass locally. The previous fix added `wait_for_process` polling on the rotated mount file, but `validate_jmes_mount` also asserts on the synced Kubernetes Secret object (`kubectl get secret <name> -o jsonpath='{.data.username}'`). In secrets-store-csi-driver v1.6.0, mount republish is driven per-volume by kubelet `NodePublishVolume`, while the synced K8s Secret is reconciled by a separate driver controller loop after the mount write completes. On slower EKS control planes (GitHub Actions runners), the synced Secret object lags behind the mount file long enough for the assertion at L121 (`[[ "$result" == $USERNAME ]]` against the decoded `data.username` field) to fire while the Secret is still stale, causing both JMES rotation tests to fail. Local clusters do not exhibit the race because mount + reconcile both complete within seconds.

### What is changing?

1. tests/integration.bats.template

  - In both JMES rotation tests (Parameter Store and Secrets Manager variants), added a second `wait_for_process` call that polls the synced Kubernetes Secret's decoded `.data.username` field for the rotated value before invoking `validate_jmes_mount`

### Related Links
- **Issue #, if available**: N/A

---

## Testing

### How was this tested?

1. Ran integration tests locally (all pass).

### When testing locally, provide testing artifact(s):

N/A

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
  *If not, why:*
- [x] I have filled out the Description and Testing sections above
  *If not, why:*
- [x] Build and Unit tests are passing
  *If not, why:*
- [x] Unit test coverage check is passing
  *If not, why:*
- [x] Integration tests pass locally
  *If not, why:*
- [x] I have updated integration tests (if needed)
  *If not, why:*
- [x] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:*
- [x] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:*
- [x] I have updated README/documentation (if needed)
  *If not, why:*
- [x] I have clearly called out breaking changes (if any)
  *If not, why:*

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
