### PR TITLE
fix(ci): create secrets/parameters per-config

### DIFF
--- a/tests/generate-test-files.py
+++ b/tests/generate-test-files.py
@@ -283,26 +283,17 @@ def main():
     else:
         action = "default"
 
-    if action == "create-secrets":
-        print("Creating secrets for all test configurations...")
-        for config_name, config in CONFIGS.items():
-            create_secrets_for_config(config["ARCH"], config["AUTH_TYPE"])
-        print("All secrets created successfully")
+    if action in ("create-secrets", "cleanup-secrets"):
+        fn = create_secrets_for_config if action == "create-secrets" else cleanup_secrets_for_config
+        target = sys.argv[2] if len(sys.argv) > 2 else None
+        targets = [target] if target else list(CONFIGS.keys())
+        for config_name in targets:
+            if config_name not in CONFIGS:
+                print(f"Unknown config: {config_name}")
+                sys.exit(1)
+            config = CONFIGS[config_name]
+            fn(config["ARCH"], config["AUTH_TYPE"])
         return
-    if action == "cleanup-secrets":
-        print("Cleaning up secrets for all test configurations...")
-        for config_name, config in CONFIGS.items():
-            cleanup_secrets_for_config(config["ARCH"], config["AUTH_TYPE"])
-        print("All secrets cleaned up successfully")
-        return
-    if action == "generate-only":
-        # Just generate files, don't manage secrets
-        pass
-    else:
-        # Default behavior: generate files and create secrets
-        print("Creating secrets for all test configurations...")
-        for config_name, config in CONFIGS.items():
-            create_secrets_for_config(config["ARCH"], config["AUTH_TYPE"])
 
     # Generate files for each configuration
     for config_name, config in CONFIGS.items():
@@ -345,12 +336,9 @@ def main():
         print(f"  - BasicTestMount-{arch}-{auth_type}.yaml")
 
     print("\nUsage:")
-    print(
-        "  ./generate-test-files.py                 # Generate files and create secrets"
-    )
-    print("  ./generate-test-files.py generate-only  # Generate files only")
-    print("  ./generate-test-files.py create-secrets # Create secrets only")
-    print("  ./generate-test-files.py cleanup-secrets # Cleanup secrets only")
+    print("  ./generate-test-files.py                                # Generate files only")
+    print("  ./generate-test-files.py create-secrets [<config>]      # Create secrets (single config or all)")
+    print("  ./generate-test-files.py cleanup-secrets [<config>]     # Cleanup secrets (single config or all)")
 
 
 if __name__ == "__main__":

--- a/tests/integration.bats.template
+++ b/tests/integration.bats.template
@@ -48,6 +48,9 @@ fi
 setup_file() {
 	log "Starting cluster setup for $CLUSTER_NAME"
 
+	log "Creating secrets and parameters for {{ARCH}}-{{AUTH_TYPE}}"
+	python3 generate-test-files.py create-secrets {{ARCH}}-{{AUTH_TYPE}}
+
 	# Create a unique kubeconfig file path for this specific test script
 	{{KUBECONFIG_VAR}}=$(mktemp)
 	export {{KUBECONFIG_VAR}}
@@ -86,6 +89,9 @@ teardown_file() {
 
 	log "Cleaning up kubeconfig file"
 	rm -f ${{KUBECONFIG_VAR}}
+
+	log "Cleaning up secrets and parameters for {{ARCH}}-{{AUTH_TYPE}}"
+	python3 generate-test-files.py cleanup-secrets {{ARCH}}-{{AUTH_TYPE}}
 
 	log "Cluster teardown completed for $CLUSTER_NAME"
 }

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -2,7 +2,6 @@
 
 cleanup() {
 	cleanup_generated_files
-	cleanup_secrets
 }
 
 check_parallel() {
@@ -39,13 +38,10 @@ delete_cluster() {
 	eksctl delete cluster --name $1 --parallel 25
 }
 
-cleanup_secrets() {
-	echo "Cleaning up secrets and parameters..."
-	python3 generate-test-files.py cleanup-secrets
-}
-
 if [[ "$1" == "clean" ]]; then
 	cleanup
+	echo "Cleaning up secrets and parameters for all configs..."
+	python3 generate-test-files.py cleanup-secrets
 
 	if [[ "$2" == "all" || "$2" == "x64" || "$2" == "pod-identity" || "$2" == "x64-pod-identity" ]]; then
 		delete_cluster integ-cluster-x64-pod-identity
@@ -63,7 +59,7 @@ if [[ "$1" == "clean" ]]; then
 	exit $?
 fi
 
-# Generate test files from templates (this also creates secrets)
+# Generate test files from templates. Each test's setup_file creates its own secrets.
 generate_test_files
 
 # Run tests based on argument


### PR DESCRIPTION
## Description

### Why is this change being made?

1. Integ configs each create secrets/parameters for all configs instead of just the active config


### What is changing?

1. `generate-test-files.py`, `integration.bats.template`, `run-tests.sh`


### Related Links
- **Issue #, if available**: N/A

---

## Testing

### How was this tested?

Running GitHub CI

### When testing locally, provide testing artifact(s):

N/A

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
  *If not, why:*
- [x] I have filled out the Description and Testing sections above
  *If not, why:*
- [x] Build and Unit tests are passing
  *If not, why:*
- [x] Unit test coverage check is passing
  *If not, why:*
- [ ] Integration tests pass locally
  *If not, why:*
- [x] I have updated integration tests (if needed)
  *If not, why:*
- [x] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:*
- [x] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:*
- [x] I have updated README/documentation (if needed)
  *If not, why:*
- [x] I have clearly called out breaking changes (if any)
  *If not, why:*

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
