### PR TITLE
ci: scan built Docker images with Trivy

### DIFF
--- a/.github/workflows/build-test-image.yml
+++ b/.github/workflows/build-test-image.yml
@@ -61,6 +61,14 @@ jobs:
           push: true
           tags: ghcr.io/${{ github.repository_owner }}/test-build:latest-${{ matrix.arch }}-${{ github.run_id }}
 
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ghcr.io/${{ github.repository_owner }}/test-build:latest-${{ matrix.arch }}-${{ github.run_id }}
+          format: table
+          exit-code: '0'
+          severity: 'CRITICAL,HIGH'
+
       - name: Output image metadata
         id: output-image
         run: |


### PR DESCRIPTION
## Description

### Why is this change being made?

1. To add Docker image CVE scanning


### What is changing?

1. Add a Trivy vulnerability scanner step to the Docker Image CI workflow. It scans the locally built test-build:latest-<arch> image (loaded by build-push-action) for CRITICAL/HIGH severity vulnerabilities. Runs in report-only mode (exit-code 0) so it surfaces findings in the logs without failing the build.


### Related Links
- **Issue #, if available**: N/A

---

## Testing

### How was this tested?

1. N/A

### When testing locally, provide testing artifact(s):

1. N/A

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [ ] I have reviewed, tested and understand all changes
  *If not, why:*
- [ ] I have filled out the Description and Testing sections above
  *If not, why:*
- [ ] Build and Unit tests are passing
  *If not, why:*
- [ ] Unit test coverage check is passing
  *If not, why:*
- [ ] Integration tests pass locally
  *If not, why:*
- [ ] I have updated integration tests (if needed)
  *If not, why:*
- [ ] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:*
- [ ] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:*
- [ ] I have updated README/documentation (if needed)
  *If not, why:*
- [ ] I have clearly called out breaking changes (if any)
  *If not, why:*

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
