### PR TITLE
Add queue setting to integration test workflow

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -11,6 +11,7 @@ concurrency:
   # Only run one workflow at a time to avoid hitting the network interface quota
   group: integration-tests
   cancel-in-progress: false
+  queue: max
 
 jobs:
   build-docker:


### PR DESCRIPTION
## Description

### Why is this change being made?

1. GitHub added a parameter to allow more than one job to wait for concurrency. Previously, only one job could wait for execution.

https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#concurrency


### What is changing?

1.


### Related Links
- **Issue #, if available**:

---

## Testing

### How was this tested?

1. 

### When testing locally, provide testing artifact(s):

1. 

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
  *If not, why:*
- [x] I have filled out the Description and Testing sections above
  *If not, why:*
- [x] Build and Unit tests are passing
  *If not, why:*
- [x] Unit test coverage check is passing
  *If not, why:*
- [x] Integration tests pass locally
  *If not, why:*
- [ ] I have updated integration tests (if needed)
  *If not, why:*
- [x] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:*
- [x] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:*
- [ ] I have updated README/documentation (if needed)
  *If not, why:*
- [ ] I have clearly called out breaking changes (if any)
  *If not, why:*

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
