### PR TITLE
Add helm value for automountServiceAccountToken

### DIFF
--- a/charts/secrets-store-csi-driver-provider-aws/templates/daemonset.yaml
+++ b/charts/secrets-store-csi-driver-provider-aws/templates/daemonset.yaml
@@ -31,6 +31,7 @@ spec:
 {{- toYaml .Values.dnsConfig | nindent 8 }}
 {{- end }}
       serviceAccountName: {{ template "provider.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       hostNetwork: false
       containers:
         - name: provider-aws-installer

--- a/charts/secrets-store-csi-driver-provider-aws/values.yaml
+++ b/charts/secrets-store-csi-driver-provider-aws/values.yaml
@@ -14,6 +14,10 @@ driverWritesSecrets: false
 commonLabels: {}
 podLabels: {}
 podAnnotations: {}
+# The provider requires a service account token to authenticate to the
+# Kubernetes API server, including for Pod Identity and IRSA token resolution.
+# Disabling this will prevent the provider from starting unless a token is
+# provided by other means.
 automountServiceAccountToken: true
 
 affinity:

--- a/charts/secrets-store-csi-driver-provider-aws/values.yaml
+++ b/charts/secrets-store-csi-driver-provider-aws/values.yaml
@@ -14,6 +14,7 @@ driverWritesSecrets: false
 commonLabels: {}
 podLabels: {}
 podAnnotations: {}
+automountServiceAccountToken: true
 
 affinity:
   nodeAffinity:


### PR DESCRIPTION
## Description

### Why is this change being made?

This adds Helm chart opiotn for users who need to control whether AWS provider Daemonset automatically mounts k8s service account token


### What is changing?

- `automountServiceAccountToken` values to chart values.yaml
- renders spec.template.spec.automountServiceAccountToken in proivider Daemonset template from that.


### Related Links
- **Issue #, if available**: NA

---

## Testing

### How was this tested?

1. Verified chart changes are limited to the new Helm value and Daemonset pod spec rendering.

### When testing locally, provide testing artifact(s):

1. 

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
  *If not, why:*
- [x] I have filled out the Description and Testing sections above
  *If not, why:*
- [ ] Build and Unit tests are passing
  *If not, why:*
- [ ] Unit test coverage check is passing
  *If not, why:*
- [ ] Integration tests pass locally
  *If not, why:*
- [x] I have updated integration tests (if needed)
  *If not, why:*
- [x] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:*
- [x] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:*
- [ ] I have updated README/documentation (if needed)
  *If not, why:*
- [x] I have clearly called out breaking changes (if any)
  *If not, why:*

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
