### PR TITLE
Use pull_request_target

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -1,7 +1,11 @@
 name: Claude Code Review
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, ready_for_review, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   review:
@@ -15,6 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
 
       - name: Configure AWS Credentials


### PR DESCRIPTION
## Description

### Why is this change being made?

1. PRs from forks are unable to assume the role to run Claude code review because the OIDC token contains the fork context. 


### What is changing?

1. Use `pull_request_target` to run the workflow from main instead. Assumption is still gated on the github environment `code-review` which requires maintainer approval.
2. Added concurrency to try to reduce the number of pending workflows kept open when a PR is updated. Now old pending workflows should cancel themselves. There's no point in leaving comments if the PR has since been updated. 

### Related Links
- **Issue #, if available**:

---

## Testing

### How was this tested?

1. 

### When testing locally, provide testing artifact(s):

1. 

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
  *If not, why:*
- [x] I have filled out the Description and Testing sections above
  *If not, why:*
- [x] Build and Unit tests are passing
  *If not, why:*
- [x] Unit test coverage check is passing
  *If not, why:*
- [ ] Integration tests pass locally
  *If not, why:* Not applicable
- [ ] I have updated integration tests (if needed)
  *If not, why:* Not applicable
- [x] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:*
- [ ] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:* Not needed in this case.
- [ ] I have updated README/documentation (if needed)
  *If not, why:* Not needed
- [ ] I have clearly called out breaking changes (if any)
  *If not, why:* No breaking changes.

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
