### PR TITLE
Restrict provider socket permissions to 0700

### DIFF
--- a/main.go
+++ b/main.go
@@ -95,7 +95,7 @@ func main() {
 
 	listener, err := createSocket(endpoint)
 	if err != nil {
-		klog.Fatalf("Failed to create unix socket. error: %v", err)
+		klog.Fatalf("Failed to listen on unix socket. error: %v", err)
 	}
 
 	cfg, err := rest.InClusterConfig()

--- a/main.go
+++ b/main.go
@@ -55,9 +55,11 @@ func parsePodIdentityHttpTimeout(timeoutStr string) *time.Duration {
 // createSocket creates a Unix domain socket at the given path with restricted
 // permissions (0700) so that only the owner (root) can connect.
 func createSocket(endpoint string) (net.Listener, error) {
+	oldMask := syscall.Umask(0077)
 	listener, err := net.Listen("unix", endpoint)
+	syscall.Umask(oldMask)
 	if err != nil {
-		return nil, fmt.Errorf("failed to listen: %w", err)
+		return nil, fmt.Errorf("failed to listen on %s: %w", endpoint, err)
 	}
 	if err := os.Chmod(endpoint, 0700); err != nil {
 		listener.Close()

--- a/main.go
+++ b/main.go
@@ -52,6 +52,20 @@ func parsePodIdentityHttpTimeout(timeoutStr string) *time.Duration {
 	return &duration
 }
 
+// createSocket creates a Unix domain socket at the given path with restricted
+// permissions (0700) so that only the owner (root) can connect.
+func createSocket(endpoint string) (net.Listener, error) {
+	listener, err := net.Listen("unix", endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to listen: %w", err)
+	}
+	if err := os.Chmod(endpoint, 0700); err != nil {
+		listener.Close()
+		return nil, fmt.Errorf("failed to set socket permissions: %w", err)
+	}
+	return listener, nil
+}
+
 // Main entry point for the Secret Store CSI driver AWS provider. This main
 // rountine starts up the gRPC server that will listen for incoming mount
 // requests.
@@ -77,12 +91,9 @@ func main() {
 		grpcSrv.GracefulStop()
 	}()
 
-	listener, err := net.Listen("unix", endpoint)
+	listener, err := createSocket(endpoint)
 	if err != nil {
-		klog.Fatalf("Failed to listen on unix socket. error: %v", err)
-	}
-	if err := os.Chmod(endpoint, 0700); err != nil {
-		klog.Fatalf("Failed to set socket permissions. error: %v", err)
+		klog.Fatalf("Failed to create unix socket. error: %v", err)
 	}
 
 	cfg, err := rest.InClusterConfig()

--- a/main.go
+++ b/main.go
@@ -81,6 +81,9 @@ func main() {
 	if err != nil {
 		klog.Fatalf("Failed to listen on unix socket. error: %v", err)
 	}
+	if err := os.Chmod(endpoint, 0700); err != nil {
+		klog.Fatalf("Failed to set socket permissions. error: %v", err)
+	}
 
 	cfg, err := rest.InClusterConfig()
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )

--- a/main_test.go
+++ b/main_test.go
@@ -143,7 +143,7 @@ func TestFlagParsing(t *testing.T) {
 
 func TestCreateSocket(t *testing.T) {
 	dir := t.TempDir()
-	endpoint := fmt.Sprintf("%s/aws.sock", dir)
+	endpoint := filepath.Join(dir, "aws.sock")
 
 	listener, err := createSocket(endpoint)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -150,7 +150,6 @@ func TestCreateSocket(t *testing.T) {
 		t.Fatalf("createSocket failed: %v", err)
 	}
 	defer listener.Close()
-	defer os.Remove(endpoint)
 
 	info, err := os.Stat(endpoint)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"net"
 	"os"
 	"testing"
 	"time"
@@ -142,20 +141,16 @@ func TestFlagParsing(t *testing.T) {
 	}
 }
 
-func TestSocketPermissions(t *testing.T) {
+func TestCreateSocket(t *testing.T) {
 	dir := t.TempDir()
 	endpoint := fmt.Sprintf("%s/aws.sock", dir)
 
-	listener, err := net.Listen("unix", endpoint)
+	listener, err := createSocket(endpoint)
 	if err != nil {
-		t.Fatalf("Failed to create socket: %v", err)
+		t.Fatalf("createSocket failed: %v", err)
 	}
 	defer listener.Close()
 	defer os.Remove(endpoint)
-
-	if err := os.Chmod(endpoint, 0700); err != nil {
-		t.Fatalf("Failed to chmod socket: %v", err)
-	}
 
 	info, err := os.Stat(endpoint)
 	if err != nil {
@@ -165,5 +160,12 @@ func TestSocketPermissions(t *testing.T) {
 	perm := info.Mode().Perm()
 	if perm != 0700 {
 		t.Errorf("Expected socket permissions 0700, got %04o", perm)
+	}
+}
+
+func TestCreateSocket_InvalidPath(t *testing.T) {
+	_, err := createSocket("/nonexistent/path/aws.sock")
+	if err == nil {
+		t.Error("Expected error for invalid path, got nil")
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"flag"
+	"fmt"
+	"net"
 	"os"
 	"testing"
 	"time"
@@ -137,5 +139,31 @@ func TestFlagParsing(t *testing.T) {
 				t.Errorf("Expected flag value %s, got %s", tt.expectedFlag, *testPodIdentityHttpTimeout)
 			}
 		})
+	}
+}
+
+func TestSocketPermissions(t *testing.T) {
+	dir := t.TempDir()
+	endpoint := fmt.Sprintf("%s/aws.sock", dir)
+
+	listener, err := net.Listen("unix", endpoint)
+	if err != nil {
+		t.Fatalf("Failed to create socket: %v", err)
+	}
+	defer listener.Close()
+	defer os.Remove(endpoint)
+
+	if err := os.Chmod(endpoint, 0700); err != nil {
+		t.Fatalf("Failed to chmod socket: %v", err)
+	}
+
+	info, err := os.Stat(endpoint)
+	if err != nil {
+		t.Fatalf("Failed to stat socket: %v", err)
+	}
+
+	perm := info.Mode().Perm()
+	if perm != 0700 {
+		t.Errorf("Expected socket permissions 0700, got %04o", perm)
 	}
 }


### PR DESCRIPTION
## Description

### Why is this change being made?

1. The provider Unix socket (`aws.sock`) is created with 0755 permissions, allowing any process on the node with hostPath access to connect and send forged gRPC requests.
2. This is expected behavior per the [upstream driver design](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/v1.6.0/pkg/secrets-store/provider_client.go#L104) (filesystem ACLs only), but restricting permissions is a low-cost hardening improvement that blocks non-root attackers.

### What is changing?

1. After creating the Unix socket via `net.Listen`, we now call `os.Chmod(endpoint, 0700)` to restrict access to the socket owner (root) only.
3. Added `TestSocketPermissions` unit test to verify the socket is set to 0700 after creation.

### Related Links
- **Issue #, if available**: N/A

---

## Testing

### How was this tested?

1. Unit test `TestSocketPermissions` creates a socket in a temp dir, applies chmod 0700, and verifies the resulting permissions.
2. The CSI driver runs as root and will continue to connect successfully since 0700 grants owner full access.

### When testing locally, provide testing artifact(s):

1. 

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
  *If not, why:*
- [x] I have filled out the Description and Testing sections above
  *If not, why:*
- [ ] Build and Unit tests are passing
  *If not, why:* 
- [ ] Unit test coverage check is passing
  *If not, why:* 
- [ ] Integration tests pass locally
  *If not, why:*
- [ ] I have updated integration tests (if needed)
  *If not, why:* N/A
- [x] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:*
- [x] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:*
- [ ] I have updated README/documentation (if needed)
  *If not, why:*
- [ ] I have clearly called out breaking changes (if any)
  *If not, why:* N/A

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.