### PR TITLE
Allow unsafe PR checkout on the integ and code review workflows.

### DIFF
--- a/.github/workflows/build-test-image.yml
+++ b/.github/workflows/build-test-image.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          allow-unsafe-pr-checkout: true
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Login to GitHub Container Registry

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -19,6 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          allow-unsafe-pr-checkout: true
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
 


### PR DESCRIPTION
## Description

### Why is this change being made?

1. The code review and integ workflows retrieve PR code to review and test it.
2. These workflows must run as `pull_request_target` to perform OIDC with AWS roles from the upstream repo.
3. Github updated the checkout action to require a flag to checkout unsafe code in `pull_request_target` https://github.com/actions/checkout/pull/2500
4. We already gate these workflows on environment review and label application, respectively.


### What is changing?

1. Add the flag.


### Related Links
- **Issue #, if available**:

---

## Testing

### How was this tested?

1. No testing.

### When testing locally, provide testing artifact(s):

1. 

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
  *If not, why:*
- [x] I have filled out the Description and Testing sections above
  *If not, why:*
- [ ] Build and Unit tests are passing
  *If not, why:*
- [ ] Unit test coverage check is passing
  *If not, why:*
- [ ] Integration tests pass locally
  *If not, why:*
- [ ] I have updated integration tests (if needed)
  *If not, why:*
- [x] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:*
- [ ] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:*
- [ ] I have updated README/documentation (if needed)
  *If not, why:*
- [ ] I have clearly called out breaking changes (if any)
  *If not, why:*

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
