### PR TITLE
ci: use code-review skill with max effort on Opus 5

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -42,18 +42,14 @@ jobs:
           additional_permissions: |
             actions: read
           claude_args: |
-            --model us.anthropic.claude-opus-4-8
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --model us.anthropic.claude-opus-5
+            --effort max
+            --allowedTools "Skill,Glob,Grep,Read,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
 
           track_progress: true # ✨ Enables tracking comments
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Please review this pull request with a focus on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Security implications
-            - Performance considerations
-
+            Use the /code-review skill.
             Provide detailed feedback using inline comments for specific issues.


### PR DESCRIPTION
## Description

### Why is this change being made?

1. The Claude review step used a hand-rolled prompt ("focus on code quality, bugs, security, performance") instead of the maintained `code-review` skill, so the review depth here drifts from the skill as it improves.

### What is changing?

1. Prompt now invokes `/code-review` instead of the custom review criteria.
2. `--allowedTools` gains `Skill,Glob,Grep,Read` — per [claude-code-action#1003](https://github.com/anthropics/claude-code-action/issues/1003), `Skill` is what makes skill invocation work from the action; the read tools let the skill inspect files.
3. Model bumped to `us.anthropic.claude-opus-5`, and `--effort max` added.

Repo/PR-number vars and the inline-comment instruction are unchanged.

### Related Links
- **Issue #, if available**: anthropics/claude-code-action#1003

---

## Testing

### How was this tested?

1. `actionlint` — no new findings (the three pre-existing ones are unrelated: `allow-unsafe-pr-checkout` and the `create-github-app-token` client-id inputs, which actionlint's bundled action metadata is behind on).
2. YAML parse verified.

**Not verified end to end.** `pull_request_target` runs the workflow from the base branch, so this PR is reviewed by `main`'s current definition — the new prompt and flags first execute on the next PR after merge. Worth watching that run.

---

## Reviewee Checklist

- [x] I have reviewed, tested and understand all changes
- [x] I have filled out the Description and Testing sections above
- [ ] Build and Unit tests are passing
  *If not, why:* CI-only change; no Go source touched.
- [ ] Unit test coverage check is passing
  *If not, why:* as above.
- [ ] Integration tests pass locally
  *If not, why:* as above.
- [x] I have updated integration tests (if needed) — n/a
- [x] I have ensured no sensitive information is leaking
- [x] I have added explanatory comments for complex logic, new classes/methods and new tests — n/a
- [x] I have updated README/documentation (if needed) — n/a
- [x] I have clearly called out breaking changes (if any) — none

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.