### PR TITLE
fix: default GOPROXY to module proxy in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ WORKDIR /workdir
 RUN apk add git build-base
 
 # Override on networks that cannot reach proxy.golang.org, e.g.
-#   make docker-buildx GOPROXY=direct
 #   docker build --build-arg GOPROXY=direct .
+#   make GOPROXY=direct    # full build+push; see README "Private Builds" for PRIVREPO
 ARG GOPROXY=https://proxy.golang.org,direct
 ENV GOPROXY=${GOPROXY}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ WORKDIR /workdir
 
 RUN apk add git build-base
 
-# Override to `direct` on networks that cannot reach proxy.golang.org.
+# Override on networks that cannot reach proxy.golang.org, e.g.
+#   make docker-buildx GOPROXY=direct
+#   docker build --build-arg GOPROXY=direct .
 ARG GOPROXY=https://proxy.golang.org,direct
 ENV GOPROXY=${GOPROXY}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,10 @@ RUN echo "Running on ${BUILDPLATFORM}, building for ${TARGETPLATFORM}."
 WORKDIR /workdir
 
 RUN apk add git build-base
-RUN go env -w GOPROXY=direct
+
+# Override to `direct` on networks that cannot reach proxy.golang.org.
+ARG GOPROXY=https://proxy.golang.org,direct
+ENV GOPROXY=${GOPROXY}
 
 COPY go.mod .
 COPY go.sum .

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ docker-buildx:
 	docker buildx build \
 				--platform linux/arm64,linux/amd64 \
 				--build-arg LDFLAGS=$(LDFLAGS) \
-				$(if $(GOPROXY),--build-arg GOPROXY=$(GOPROXY)) \
+				--build-arg 'GOPROXY=$(GOPROXY)' \
 				--push \
 				-t $(REGISTRY_NAME):latest \
 				-t $(REGISTRY_NAME):$(FULL_REV) \

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ docker-buildx:
 	docker buildx build \
 				--platform linux/arm64,linux/amd64 \
 				--build-arg LDFLAGS=$(LDFLAGS) \
+				$(if $(GOPROXY),--build-arg GOPROXY=$(GOPROXY)) \
 				--push \
 				-t $(REGISTRY_NAME):latest \
 				-t $(REGISTRY_NAME):$(FULL_REV) \

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ docker-buildx:
 	docker buildx build \
 				--platform linux/arm64,linux/amd64 \
 				--build-arg LDFLAGS=$(LDFLAGS) \
-				--build-arg 'GOPROXY=$(GOPROXY)' \
+				$(if $(GOPROXY),--build-arg 'GOPROXY=$(GOPROXY)') \
 				--push \
 				-t $(REGISTRY_NAME):latest \
 				-t $(REGISTRY_NAME):$(FULL_REV) \


### PR DESCRIPTION
## Description

### Why is this change being made?

1. The Docker build pinned `GOPROXY=direct`, so `go mod download` resolved every module from its origin instead of the module proxy. That made the build depend on gopkg.in's `?go-get=1` redirector, which is returning `502 Proxy Error` for GitHub Actions runners:

   ```
   # get https://gopkg.in/yaml.v2?go-get=1: 502 Proxy Error (10.138s)
   go: gopkg.in/evanphx/json-patch.v4@v4.13.0: unrecognized import path "gopkg.in/evanphx/json-patch.v4": reading https://gopkg.in/evanphx/json-patch.v4?go-get=1: 502 Proxy Error
   ```

   This blocked the "Build and push test docker image" workflow across all four attempts of run 32774071533, while the Go workflow succeeded on the same commit because it uses the default `GOPROXY`.

### What is changing?

1. `Dockerfile`: `GOPROXY` becomes a build arg defaulting to Go's normal `https://proxy.golang.org,direct` chain, so module fetches hit the proxy cache and no longer depend on gopkg.in being reachable.
2. `Makefile`: `docker-buildx` passes the host's `go env GOPROXY` through as `--build-arg GOPROXY`, so networks that cannot reach `proxy.golang.org` keep working without editing the Dockerfile. Note that Go falls back from the proxy to `direct` only on HTTP 404/410, not on network errors, so the override is still needed on such networks.

### Related Links
- **Issue #, if available**: n/a

---

## Testing

### How was this tested?

1. Both matrix legs of "Build and push test docker image" pass on this branch (run 32778267134): `ubuntu-24.04-arm` in 1m19s and `ubuntu-latest` in 1m46s. The same arm leg failed at `go mod download` on all four attempts of run 32774071533 before this change.
2. Go workflow passes on this branch (run 32778170893), including unit tests, fuzz targets, staticcheck, and Codecov.
3. Local `docker build` with the override, confirming the previous behavior is still available.

### When testing locally, provide testing artifact(s):

1. Build with the override, and the resulting `GOPROXY` inside the builder stage:

   ```
   $ docker build --no-cache --target go --build-arg GOPROXY=direct .
   ...
   #15 DONE 14.0s
   $ docker run --rm --entrypoint sh <image> -c 'go env GOPROXY'
   direct
   ```

2. Makefile passthrough resolving from the host:

   ```
   $ make -n docker-buildx | grep -o 'build-arg GOPROXY=[^ ]*'
   build-arg GOPROXY=direct
   ```

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
  *If not, why:*
- [x] I have filled out the Description and Testing sections above
  *If not, why:*
- [x] Build and Unit tests are passing
  *If not, why:*
- [x] Unit test coverage check is passing
  *If not, why:*
- [ ] Integration tests pass locally
  *If not, why:* Not run locally; they are running in CI on this PR via the `safe-to-test` label. This change alters only how modules are fetched during the Docker build, not provider behavior.
- [x] I have updated integration tests (if needed)
  *If not, why:* No test change needed; build-time dependency resolution only.
- [x] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:* `ENV GOPROXY` lives only in the discarded `go` builder stage; the published image is built `FROM scratch`.
- [x] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:*
- [x] I have updated README/documentation (if needed)
  *If not, why:* No docs reference the Docker build args or `GOPROXY`.
- [x] I have clearly called out breaking changes (if any)
  *If not, why:* None. Default behavior only improves proxy usage; the previous `direct` behavior remains available via build arg.

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
